### PR TITLE
V3.0.1 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ v3.0.1 (Feb 2018)
 The "Select File" in File tab generated an unnecessary error if the user cancelled the selection. Now it just cancels as expected
 If QuickHash cannot get a handle to a file becuase it is open without share permissions by the OS, QuickHash should now silently proceed and simply report that the file could not be accessed in the hash column
 The SQLite database is now located in the systems temporary directory and deleted afterwards rather than appearing in the root of the launch path.
+In the FileS tab, if the user aborted a scan using Stop button and selected a new folder, nothing would happen because a boolean flag was not being reset properly. That was fixed. Date formatting also adjusted to YY/MM/DD (e.g. 18/01/31)
 
 v3.0.0 (Jan 2018)
 Now with SQLite!! The reason why the development numbering has moved to v3.0...the first whole number release since v2.0 in 2013, is due to the move to SQLIte. This has been a massive re-write and a total overhaul of large parts of the program. SQLite adds many areas of functionality that was not possible before, so some tick box options have been removed in exchange for right click menu options. As a result of using SQLite, once the hashing has been conducted the user can still save and copy data to clipboard as he could before, but in addition Quickhash can now list duplicate files, match filenames, match file paths, and copy individual cells, and it will list the data in the blink of an eye. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@ Version History
 ===============
 v3.0.1 (Feb 2018)
 The "Select File" in File tab generated an unnecessary error if the user cancelled the selection. Now it just cancels as expected
-If QuickHash cannot get a handle to a file becuase it is open without share permissions by the OS, QuickHash should now silently proceed and simply report that the file could not be accessed in the hash column
+If QuickHash cannot get a handle to a file because it is open without share permissions by the OS, QuickHash should now silently proceed and simply report that the file could not be accessed in the hash column
 The SQLite database is now located in the systems temporary directory and deleted afterwards rather than appearing in the root of the launch path.
 In the FileS tab, if the user aborted a scan using Stop button and selected a new folder, nothing would happen because a boolean flag was not being reset properly. That was fixed. Date formatting also adjusted to YY/MM/DD (e.g. 18/01/31)
+In the Disks tab, if the user had removable drive bays, often they would get error : "Could not convert variant of type (Null) into type Int64". That should now be fixed. 
+In the disks tab, dates were being shown as dd/mm/yy. Changed to YY/MM/DD in line with the rest of QuickHash
+In the disks tab, logical volumes were being shown with their API prefix (e.g. \\?\F:). It still will on initial selection but thereafter (once the hashing has started) it is converted to "F:"
 
 v3.0.0 (Jan 2018)
 Now with SQLite!! The reason why the development numbering has moved to v3.0...the first whole number release since v2.0 in 2013, is due to the move to SQLIte. This has been a massive re-write and a total overhaul of large parts of the program. SQLite adds many areas of functionality that was not possible before, so some tick box options have been removed in exchange for right click menu options. As a result of using SQLite, once the hashing has been conducted the user can still save and copy data to clipboard as he could before, but in addition Quickhash can now list duplicate files, match filenames, match file paths, and copy individual cells, and it will list the data in the blink of an eye. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 Version History
 ===============
+v3.0.1 (Feb 2018)
+The "Select File" in File tab generated an unnecessary error if the user cancelled the selection. Now it just cancels as expected
+If QuickHash cannot get a handle to a file becuase it is open without share permissions by the OS, QuickHash should now silently proceed and simply report that the file could not be accessed in the hash column
+The SQLite database is now located in the systems temporary directory and deleted afterwards rather than appearing in the root of the launch path.
 
-v3.0.0
+v3.0.0 (Jan 2018)
 Now with SQLite!! The reason why the development numbering has moved to v3.0...the first whole number release since v2.0 in 2013, is due to the move to SQLIte. This has been a massive re-write and a total overhaul of large parts of the program. SQLite adds many areas of functionality that was not possible before, so some tick box options have been removed in exchange for right click menu options. As a result of using SQLite, once the hashing has been conducted the user can still save and copy data to clipboard as he could before, but in addition Quickhash can now list duplicate files, match filenames, match file paths, and copy individual cells, and it will list the data in the blink of an eye. 
 
 Added the often requested feature of hash lookup from existing hash set (arrived with Beta2 ofr v3.0.0). Available only in the FileS tab by way of a checkbox called 'Load hashlist' and a button to select the hash list file. So if the user has a list of existing hashes in a text file, he can import that into QuickHash and then compute hashes of files in a folder using the FileS tab. Any hashes that are in the hash list but are not computed of files in the selected folder will be output with 'Yes' or 'No' respectively in the display grid. The user can then sort and filter by those values. In tests, several hundred existing hashes are imported in less than one second using only a dozen or so additional Mb of RAM.

--- a/dbases_sqlite.lfm
+++ b/dbases_sqlite.lfm
@@ -12,9 +12,9 @@ object frmSQLiteDBases: TfrmSQLiteDBases
   LCLVersion = '1.6.4.0'
   object lblConnectionStatus: TLabel
     Left = 32
-    Height = 13
+    Height = 16
     Top = 32
-    Width = 72
+    Width = 94
     Caption = 'Not Connected'
     ParentColor = False
   end

--- a/dbases_sqlite.lfm
+++ b/dbases_sqlite.lfm
@@ -1,7 +1,7 @@
 object frmSQLiteDBases: TfrmSQLiteDBases
-  Left = 1213
+  Left = 1137
   Height = 506
-  Top = 258
+  Top = 40
   Width = 252
   Caption = 'frmSQLiteDBases'
   ClientHeight = 506
@@ -12,9 +12,9 @@ object frmSQLiteDBases: TfrmSQLiteDBases
   LCLVersion = '1.6.4.0'
   object lblConnectionStatus: TLabel
     Left = 32
-    Height = 16
+    Height = 13
     Top = 32
-    Width = 94
+    Width = 72
     Caption = 'Not Connected'
     ParentColor = False
   end

--- a/dbases_sqlite.pas
+++ b/dbases_sqlite.pas
@@ -154,8 +154,8 @@ begin
       SQLDBLibraryLoaderOSX.LoadLibrary;
       // Set the filename of the sqlite database
       strFileNameRandomiser := FormatDateTime('YYYY-MM-DD_HH-MM-SS', Now); // use a randomised filename suffix to enable multiple instances
-      // Determine a safe place to write the SQLite database file to;
-      SafePlaceForDB := GetAppConfigDir(false); //GetUserDir returns /Users/Username/ on OSX but GetAppConfigDir safer I think;
+      //  write the SQLite database file to /tmp;
+      SafePlaceForDB := '/tmp/';
       if ForceDirectories(SafePlaceForDB) then
       begin
         SQLite3Connection1.DatabaseName := SafePlaceForDB + 'QuickHashDBOSX_' + strFileNameRandomiser + '.sqlite';
@@ -218,19 +218,18 @@ begin
       SQLDBLibraryLoaderLinux.LoadLibrary;
       // Set the filename of the sqlite database
       strFileNameRandomiser := FormatDateTime('YYYY-MM-DD_HH-MM-SS', Now); // use a randomised filename suffix to enable multiple instances
-      SQLite3Connection1.DatabaseName := 'QuickHashDBLinux_' + strFileNameRandomiser + '.sqlite';
-      // Create the database and connect to it
-      CreateDatabase(SQLite3Connection1.DatabaseName);
-
-      if SQLIte3Connection1.Connected then
+      //  write the SQLite database file to /tmp
+      SafePlaceForDB := '/tmp/';
+      if ForceDirectories(SafePlaceForDB) then
       begin
-        // None of this is visibile to the user. We just need to alert him if connection fails
-        lblConnectionStatus.Caption:= 'SQLite3 Database connection active';
+        SQLite3Connection1.DatabaseName := SafePlaceForDB + 'QuickHashDBLinux_' + strFileNameRandomiser + '.sqlite';
+        // Create the database
+        CreateDatabase(SQLite3Connection1.DatabaseName);
+        if SQLIte3Connection1.Connected then lblConnectionStatus.Caption:= 'SQLite3 Database connection active';
       end
-        else
+      else
         begin
-          ShowMessage('Cannot create SQLite database. Probably SQLite is not installed on your system (could not find libsqlite3.so.0). Exiting');
-          abort;
+          Showmessage('Could not create folder ' + SafePlaceForDB + ' for ' + SQLite3Connection1.DatabaseName);
         end;
       end;
     {$endif}

--- a/dbases_sqlite.pas
+++ b/dbases_sqlite.pas
@@ -132,17 +132,21 @@ begin
     SQLDBLibraryLoaderWindows.LoadLibrary;
     // Set the filename of the sqlite database
     strFileNameRandomiser := FormatDateTime('YYYY-MM-DD_HH-MM-SS', Now); // use a randomised filename suffix to enable multiple instances
-    SQLite3Connection1.DatabaseName := 'QuickHashDBWin_' + strFileNameRandomiser + '.sqlite';
-    // Create the database
-    CreateDatabase(SQLite3Connection1.DatabaseName);
-    if SQLIte3Connection1.Connected then
+    SafePlaceForDB := GetTempDir;
+    if ForceDirectories(SafePlaceForDB) then
     begin
-      lblConnectionStatus.Caption:= 'SQLite3 Database connection active';
-    end
-    else
-    begin
-      ShowMessage('Cannot create SQLite database. Missing SQLite DLLs. Functionaliy will be reduced');
-      abort; // Quit
+      SQLite3Connection1.DatabaseName := SafePlaceForDB + 'QuickHashDBWin_' + strFileNameRandomiser + '.sqlite';
+      // Create the database
+      CreateDatabase(SQLite3Connection1.DatabaseName);
+      if SQLIte3Connection1.Connected then
+      begin
+        lblConnectionStatus.Caption:= 'SQLite3 Database connection active';
+      end
+      else
+        begin
+          ShowMessage('Cannot create SQLite database. Missing SQLite DLLs. Functionaliy will be reduced');
+          abort; // Quit
+        end;
     end;
     {$endif}
     {$ifdef darwin}
@@ -154,8 +158,8 @@ begin
       SQLDBLibraryLoaderOSX.LoadLibrary;
       // Set the filename of the sqlite database
       strFileNameRandomiser := FormatDateTime('YYYY-MM-DD_HH-MM-SS', Now); // use a randomised filename suffix to enable multiple instances
-      //  write the SQLite database file to /tmp;
-      SafePlaceForDB := '/tmp/';
+      //  write the SQLite database file to system temp;
+      SafePlaceForDB := GetTempDir;
       if ForceDirectories(SafePlaceForDB) then
       begin
         SQLite3Connection1.DatabaseName := SafePlaceForDB + 'QuickHashDBOSX_' + strFileNameRandomiser + '.sqlite';
@@ -218,8 +222,8 @@ begin
       SQLDBLibraryLoaderLinux.LoadLibrary;
       // Set the filename of the sqlite database
       strFileNameRandomiser := FormatDateTime('YYYY-MM-DD_HH-MM-SS', Now); // use a randomised filename suffix to enable multiple instances
-      //  write the SQLite database file to /tmp
-      SafePlaceForDB := '/tmp/';
+      //  write the SQLite database file to system temp
+      SafePlaceForDB := gettempdir;
       if ForceDirectories(SafePlaceForDB) then
       begin
         SQLite3Connection1.DatabaseName := SafePlaceForDB + 'QuickHashDBLinux_' + strFileNameRandomiser + '.sqlite';

--- a/diskmodule.lfm
+++ b/diskmodule.lfm
@@ -1,10 +1,10 @@
 object frmDiskHashingModule: TfrmDiskHashingModule
-  Left = 807
-  Height = 623
-  Top = 225
+  Left = 435
+  Height = 529
+  Top = 166
   Width = 787
   Caption = 'QuickHash v3.0.0 - Disk Hashing Module'
-  ClientHeight = 623
+  ClientHeight = 529
   ClientWidth = 787
   DefaultMonitor = dmDesktop
   OnClose = FormClose
@@ -14,25 +14,25 @@ object frmDiskHashingModule: TfrmDiskHashingModule
   LCLVersion = '1.6.4.0'
   object Label2: TLabel
     Left = 16
-    Height = 15
+    Height = 13
     Top = 88
-    Width = 46
+    Width = 38
     Caption = 'Vendor:'
     ParentColor = False
   end
   object Label3: TLabel
     Left = 16
-    Height = 15
+    Height = 13
     Top = 128
-    Width = 39
+    Width = 32
     Caption = 'Model:'
     ParentColor = False
   end
   object Label4: TLabel
     Left = 16
-    Height = 15
+    Height = 13
     Top = 168
-    Width = 57
+    Width = 46
     Caption = 'Serial No:'
     ParentColor = False
   end
@@ -65,9 +65,9 @@ object frmDiskHashingModule: TfrmDiskHashingModule
   end
   object Label5: TLabel
     Left = 16
-    Height = 15
+    Height = 13
     Top = 208
-    Width = 31
+    Width = 28
     Caption = 'Type:'
     ParentColor = False
   end
@@ -86,17 +86,17 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     Top = 14
     Width = 759
     Anchors = [akTop, akLeft, akRight]
-    ClientHeight = 592
-    ClientWidth = 757
+    ClientHeight = 576
+    ClientWidth = 755
     TabOrder = 0
     object TreeView1: TTreeView
       Left = 8
       Height = 136
       Hint = 'Left click a physical disk or logical volume to select it'#10'Right click a selection for other options'
       Top = 48
-      Width = 737
+      Width = 735
       Anchors = [akTop, akLeft, akRight]
-      DefaultItemHeight = 18
+      DefaultItemHeight = 16
       HotTrack = True
       ParentShowHint = False
       PopupMenu = PopupMenu1
@@ -109,9 +109,9 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object ledtSelectedItem: TLabeledEdit
       Left = 144
-      Height = 25
+      Height = 21
       Top = 208
-      Width = 593
+      Width = 591
       Anchors = [akTop, akLeft, akRight]
       Color = clGradientInactiveCaption
       EditLabel.AnchorSideLeft.Control = ledtSelectedItem
@@ -119,9 +119,9 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       EditLabel.AnchorSideRight.Side = asrBottom
       EditLabel.AnchorSideBottom.Control = ledtSelectedItem
       EditLabel.Left = 144
-      EditLabel.Height = 15
-      EditLabel.Top = 190
-      EditLabel.Width = 593
+      EditLabel.Height = 13
+      EditLabel.Top = 192
+      EditLabel.Width = 591
       EditLabel.Caption = 'Selected Item:'
       EditLabel.ParentColor = False
       TabOrder = 5
@@ -130,10 +130,10 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object comboHashChoice: TComboBox
       Left = 144
-      Height = 27
+      Height = 21
       Top = 248
       Width = 112
-      ItemHeight = 0
+      ItemHeight = 13
       ItemIndex = 1
       Items.Strings = (
         'MD5'
@@ -158,7 +158,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object ledtComputedHashA: TLabeledEdit
       Left = 8
-      Height = 25
+      Height = 21
       Top = 328
       Width = 464
       EditLabel.AnchorSideLeft.Control = ledtComputedHashA
@@ -166,8 +166,8 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       EditLabel.AnchorSideRight.Side = asrBottom
       EditLabel.AnchorSideBottom.Control = ledtComputedHashA
       EditLabel.Left = 8
-      EditLabel.Height = 15
-      EditLabel.Top = 310
+      EditLabel.Height = 13
+      EditLabel.Top = 312
       EditLabel.Width = 464
       EditLabel.Caption = 'Device Hash MD5'
       EditLabel.ParentColor = False
@@ -177,7 +177,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object ledtComputedHashB: TLabeledEdit
       Left = 8
-      Height = 25
+      Height = 21
       Top = 384
       Width = 464
       EditLabel.AnchorSideLeft.Control = ledtComputedHashB
@@ -185,8 +185,8 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       EditLabel.AnchorSideRight.Side = asrBottom
       EditLabel.AnchorSideBottom.Control = ledtComputedHashB
       EditLabel.Left = 8
-      EditLabel.Height = 15
-      EditLabel.Top = 366
+      EditLabel.Height = 13
+      EditLabel.Top = 368
       EditLabel.Width = 464
       EditLabel.Caption = 'Device Hash SHA-1'
       EditLabel.ParentColor = False
@@ -205,10 +205,10 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object cbdisks: TComboBox
       Left = 64
-      Height = 29
+      Height = 21
       Top = 8
       Width = 288
-      ItemHeight = 0
+      ItemHeight = 13
       OnChange = cbdisksChange
       Style = csDropDownList
       TabOrder = 7
@@ -216,16 +216,16 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object Label1: TLabel
       Left = 16
-      Height = 15
+      Height = 13
       Top = 16
-      Width = 29
+      Width = 23
       Caption = 'Disk:'
       ParentColor = False
       Visible = False
     end
     object ledtComputedHashC: TLabeledEdit
       Left = 8
-      Height = 25
+      Height = 21
       Top = 440
       Width = 735
       EditLabel.AnchorSideLeft.Control = ledtComputedHashC
@@ -233,8 +233,8 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       EditLabel.AnchorSideRight.Side = asrBottom
       EditLabel.AnchorSideBottom.Control = ledtComputedHashC
       EditLabel.Left = 8
-      EditLabel.Height = 15
-      EditLabel.Top = 422
+      EditLabel.Height = 13
+      EditLabel.Top = 424
       EditLabel.Width = 735
       EditLabel.Caption = 'Device Hash SHA256'
       EditLabel.ParentColor = False
@@ -244,7 +244,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object ledtComputedHashD: TLabeledEdit
       Left = 8
-      Height = 25
+      Height = 21
       Top = 489
       Width = 735
       EditLabel.AnchorSideLeft.Control = ledtComputedHashD
@@ -252,8 +252,8 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       EditLabel.AnchorSideRight.Side = asrBottom
       EditLabel.AnchorSideBottom.Control = ledtComputedHashD
       EditLabel.Left = 8
-      EditLabel.Height = 15
-      EditLabel.Top = 471
+      EditLabel.Height = 13
+      EditLabel.Top = 473
       EditLabel.Width = 735
       EditLabel.Caption = 'Device Hash SHA512'
       EditLabel.ParentColor = False
@@ -263,10 +263,10 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object cbLogFile: TCheckBox
       Left = 528
-      Height = 22
+      Height = 17
       Hint = 'Software title, Hashes, start times, '#13#10'end times, time taken, dates etc will '#13#10'be logged at the end of the process'
       Top = 240
-      Width = 182
+      Width = 148
       Caption = 'Create and save a log file?'
       Checked = True
       OnChange = cbLogFileChange
@@ -277,7 +277,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object ledtComputedHashE: TLabeledEdit
       Left = 8
-      Height = 25
+      Height = 21
       Top = 544
       Width = 735
       EditLabel.AnchorSideLeft.Control = ledtComputedHashE
@@ -285,8 +285,8 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       EditLabel.AnchorSideRight.Side = asrBottom
       EditLabel.AnchorSideBottom.Control = ledtComputedHashE
       EditLabel.Left = 8
-      EditLabel.Height = 15
-      EditLabel.Top = 526
+      EditLabel.Height = 13
+      EditLabel.Top = 528
       EditLabel.Width = 735
       EditLabel.Caption = 'Device Hash xxHash'
       EditLabel.ParentColor = False
@@ -295,10 +295,10 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object lblschedulertickboxDiskModule: TCheckBox
       Left = 288
-      Height = 22
+      Height = 17
       Hint = 'Tick to enable scheduler'
       Top = 240
-      Width = 78
+      Width = 64
       Caption = 'Start at: '
       OnChange = lblschedulertickboxDiskModuleChange
       TabOrder = 12
@@ -308,7 +308,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
       Height = 21
       Hint = 'Selected date and time in '#13#10'future to start disk hashing'
       Top = 240
-      Width = 147
+      Width = 121
       CenturyFrom = 1941
       MaxDate = 73050
       MinDate = 42736
@@ -332,7 +332,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
     end
     object lblDiskHashSchedulerStatus: TLabel
       Left = 288
-      Height = 15
+      Height = 13
       Top = 272
       Width = 12
       Caption = '...'

--- a/diskmodule.lfm
+++ b/diskmodule.lfm
@@ -3,7 +3,7 @@ object frmDiskHashingModule: TfrmDiskHashingModule
   Height = 529
   Top = 166
   Width = 787
-  Caption = 'QuickHash v3.0.0 - Disk Hashing Module'
+  Caption = 'QuickHash v3.0.1 - Disk Hashing Module'
   ClientHeight = 529
   ClientWidth = 787
   DefaultMonitor = dmDesktop

--- a/diskmodule.lfm
+++ b/diskmodule.lfm
@@ -1,7 +1,7 @@
 object frmDiskHashingModule: TfrmDiskHashingModule
-  Left = 435
+  Left = 436
   Height = 529
-  Top = 166
+  Top = 0
   Width = 787
   Caption = 'QuickHash v3.0.1 - Disk Hashing Module'
   ClientHeight = 529

--- a/diskmodule.pas
+++ b/diskmodule.pas
@@ -170,7 +170,6 @@ var
   MissingFileCount : integer;
 begin
   Stop := false;
-  NullStrictConvert := False;
   MissingFileCount := 0;
   ExecutionCount := 0;
   ledtComputedHashA.Enabled := false;
@@ -231,6 +230,7 @@ end;
 
 procedure TfrmDiskHashingModule.btnRefreshDiskListClick(Sender: TObject);
 begin
+  NullStrictConvert := False; // Hopefully avoid "could not convert variant of type (Null) into type Int64" errors
   {$ifdef Windows}
   try
     TreeView1.Items.Clear;
@@ -1758,10 +1758,19 @@ begin
               begin
                 DriveLetter    := GetJustDriveLetter(Val3);
                 DriveLetterID  := GetDriveIDFromLetter(DriveLetter);
+
                 intDriveSize   := DiskSize(DriveLetterID);
-                strDiskSize    := FormatByteSize(intDriveSize);
+                if intDriveSize > 0 then
+                 begin
+                   strDiskSize := FormatByteSize(intDriveSize);
+                 end else strDiskSize := '0';
+
                 intFreeSpace   := DiskFree(DriveLetterID);
-                strFreeSpace   := FormatByteSize(intFreeSpace);
+                if intFreeSpace > 0 then
+                begin
+                   strFreeSpace   := FormatByteSize(intFreeSpace);
+                end else strFreeSpace := '0';
+
                 strVolumeName  := GetVolumeName(DriveLetter[1]);
                 frmDiskHashingModule.TreeView1.Items.AddChild(DriveLetterNode, Val3 + ' (' + strVolumeName + ', Size: ' + strDiskSize + ', Free Space: ' + strFreeSpace + ')');
               end;

--- a/diskmodule.pas
+++ b/diskmodule.pas
@@ -112,6 +112,7 @@ type
   public
     BytesPerSector : integer;
     StartHashing : boolean;
+    NullStrictConvert : boolean;
     { public declarations }
   end;
 
@@ -131,6 +132,7 @@ var
   function VarStrNull(const V:OleVariant):string;
   function GetWMIObject(const objectName: String): IDispatch;
   function VarArrayToStr(const vArray: variant): string;
+  function RemoveLogicalVolPrefix(strPath : string; LongPathOverrideVal : string) : string;
 
   // Formatting functions
   function GetDiskLengthInBytes(hSelectedDisk : THandle) : Int64;
@@ -168,6 +170,7 @@ var
   MissingFileCount : integer;
 begin
   Stop := false;
+  NullStrictConvert := False;
   MissingFileCount := 0;
   ExecutionCount := 0;
   ledtComputedHashA.Enabled := false;
@@ -1104,7 +1107,9 @@ const
                    raise Exception.Create('Unable to initiate FSCTL_ALLOW_EXTENDED_DASD_IO.');
           end;
          {$endif}
-        // Source disk handle is OK. So attempt reading it
+        // Source disk handle is OK. So attempt reading it and adjust display to
+        // the friendly version, i.e. '\\?\F:' becomes 'F:'
+        ledtSelectedItem.Text := RemoveLogicalVolPrefix(ledtSelectedItem.Text, '\\?\');
 
         // First, compute the exact disk size of the disk or volume
         {$ifdef Windows}
@@ -1132,7 +1137,7 @@ const
         // hash selection and Image name.
         StartedAt := Now;
         frmProgress.lblResult.Caption := 'Hashing ' + ledtSelectedItem.Text;
-        frmProgress.lblProgressStartTime.Caption := 'Started At: ' + FormatDateTime('dd/mm/yy HH:MM:SS', StartedAt);
+        frmProgress.lblProgressStartTime.Caption := 'Started At: ' + FormatDateTime('YY/MM/DD HH:MM:SS', StartedAt);
         // Start the disk hashing...
         HashResult := HashDisk(hSelectedDisk, ExactDiskSize, HashChoice);
         // Disk hashing completed
@@ -1142,7 +1147,7 @@ const
           frmProgress.lblResult.Caption := 'Finished hashing ' + ledtSelectedItem.Text;
           EndedAt := Now;
           TimeTakenToHash := EndedAt - StartedAt;
-          frmProgress.lblProgressEndedAt.Caption := 'Ended At: '     + FormatDateTime('dd/mm/yy HH:MM:SS', EndedAt);
+          frmProgress.lblProgressEndedAt.Caption := 'Ended At: '     + FormatDateTime('YY/MM/DD HH:MM:SS', EndedAt);
           frmProgress.lblProgressTimeTaken.Caption := 'Time Taken: ' + FormatDateTime('HHH:MM:SS', TimeTakenToHash);
           end
         else
@@ -1177,9 +1182,9 @@ const
           slHashLog.Add('Device ID: '                 + SourceDevice);
           slHashLog.Add('Chosen Hash Algorithm: '     + comboHashChoice.Text);
           slHashLog.Add('=======================');
-          slHashLog.Add('Hashing Started At: '        + FormatDateTime('dd/mm/yy HH:MM:SS', StartedAt));
-          slHashLog.Add('Hashing Ended At:   '        + FormatDateTime('dd/mm/yy HH:MM:SS', EndedAt));
-          slHashLog.Add('Time Taken to hash: '       + FormatDateTime('HHH:MM:SS', TimeTakenToHash));
+          slHashLog.Add('Hashing Started At: '        + FormatDateTime('YY/MM/DD HH:MM:SS', StartedAt));
+          slHashLog.Add('Hashing Ended At:   '        + FormatDateTime('YY/MM/DD HH:MM:SS', EndedAt));
+          slHashLog.Add('Time Taken to hash: '        + FormatDateTime('HHH:MM:SS', TimeTakenToHash));
           slHashLog.Add('Hash(es) of disk : '                + #13#10 +
                         ' MD5:    ' + ledtComputedHashA.Text + #13#10 +
                         ' SHA-1:  ' + ledtComputedHashB.Text + #13#10 +
@@ -1209,6 +1214,19 @@ const
       end; // end of the 'else' statement relating to the disk handle being initiated OK
     Application.ProcessMessages;
   end;
+
+
+// RemoveLogicalVolPrefix : Converts '\\?\F:' to 'F:'
+// For display purposes only
+function RemoveLogicalVolPrefix(strPath : string; LongPathOverrideVal : string) : string;
+begin
+  result := '';
+  if LongPathOverrideVal = '\\?\' then
+  begin
+    // Delete the UNC API prefix of '\\?\' from the display
+    result := Copy(strPath, 5, (Length(strPath) - 3));
+  end;
+end;
 
 // Hash the selected disk. Returns the number of bytes successfully hashed
 function HashDisk(hDiskHandle : THandle; DiskSize : Int64; HashChoice : Integer) : Int64;
@@ -1678,7 +1696,7 @@ var
   DriveLetterID  : Byte;
   intDriveSize, intFreeSpace : Int64;
 
-begin;
+begin
   Result       := '';
   intDriveSize := 0;
   intFreeSpace := 0;

--- a/frmaboutunit.lfm
+++ b/frmaboutunit.lfm
@@ -1,7 +1,7 @@
 object frmAbout: TfrmAbout
-  Left = 533
+  Left = 540
   Height = 435
-  Top = 238
+  Top = 165
   Width = 514
   Caption = 'About QuickHash-GUI'
   ClientHeight = 435
@@ -17,22 +17,31 @@ object frmAbout: TfrmAbout
     Lines.Strings = (
       'Developed by Ted Smith (c) 2011-2018 '
       ''
-      'Home Page : http://www.quickhash-gui.org (First registered in 2011 on Sourceforge at http://sourceforge.net/projects/quickhash)'
+      'Home Page : http://www.quickhash-gui.org (First registered in 2011 on Sourceforge at '
+      'http://sourceforge.net/projects/quickhash)'
       ''
-      'Donations are welcomed! The website is hosted using AWS which is actually quite expensive! If you have found QuickHash useful to you or your business, please consider donating using PayPal at https://paypal.me/quickhash'
+      'Donations are welcomed! The website is hosted using AWS which is actually quite expensive! If '
+      'you have found QuickHash useful to you or your business, please consider donating using '
+      'PayPal at https://paypal.me/quickhash'
       ''
       'The development Github Page is : https://github.com/tedsmith/quickhash'
       ''
-      'Contributions made by DaReal Shinji (http://www.github.com/darealshinji), especially regarding repository maintenance and Debian packaging are both welcomed and acknowledged, in '
+      'Contributions made by DaReal Shinji (http://www.github.com/darealshinji), especially '
+      'regarding repository maintenance and Debian packaging are both welcomed and '
+      'acknowledged, in '
       'addition to the Lazarus forum members, who are always so helpful. '
       ''
-      'Bug Tracker is available at http://www.quickhash-gui.org/bug-tracker/ where bugs and feature requests can be submitted, reviewed and tracked. '
+      'Bug Tracker is available at http://www.quickhash-gui.org/bug-tracker/ where bugs and feature '
+      'requests can be submitted, reviewed and tracked. '
       ''
-      'For a private communication or technical help which the website does not answer, you can e-mail me at tedsmith@quickhash-gui.org, however, this should not be used as the means to ask '
+      'For a private communication or technical help which the website does not answer, you can e-'
+      'mail me at tedsmith@quickhash-gui.org, however, this should not be used as the means to ask '
       'about bugs or problems. Please use the bug tracker for that so that other users can benefit. '
       ''
-      'Created using the Lazarus IDE and the Freepascal Compiler. QuickHash is open-source and released under the GPL2 license. '
-      'The HashLib4Pascal library is licensed under MIT and developed by the talented Ugochukwu Mmaduekwe Stanley (aka Xor-el - see https://github.com/Xor-el/HashLib4Pascal).'
+      'Created using the Lazarus IDE and the Freepascal Compiler. QuickHash is open-source and '
+      'released under the GPL2 license. '
+      'The HashLib4Pascal library is licensed under MIT and developed by the talented Ugochukwu '
+      'Mmaduekwe Stanley (aka Xor-el - see https://github.com/Xor-el/HashLib4Pascal).'
     )
     ReadOnly = True
     ScrollBars = ssAutoBoth

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -12,9 +12,8 @@
     </i18n>
     <VersionInfo>
       <UseVersionInfo Value="True"/>
-      <AutoIncrementBuild Value="True"/>
       <MajorVersionNr Value="3"/>
-      <BuildNr Value="1"/>
+      <RevisionNr Value="1"/>
       <Language Value="0809"/>
       <StringTable Comments="Free, cross platform, open-source file and disk hashing software" CompanyName="Ted Smith (Ted Technology on Sourceforge)" FileDescription="File hashing GUI for Linux &amp; Windows" LegalCopyright="2011 - 2018 (c) Ted Smith" ProductName="QuickHash (www.quickhash-gui.org)" ProductVersion=""/>
     </VersionInfo>

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -91,8 +91,8 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="Unit2"/>
-        <TopLine Value="2431"/>
-        <CursorPos Y="2456"/>
+        <TopLine Value="2430"/>
+        <CursorPos X="3" Y="2434"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -254,8 +254,8 @@
         <ResourceBaseClass Value="Form"/>
         <IsVisibleTab Value="True"/>
         <EditorIndex Value="3"/>
-        <TopLine Value="1163"/>
-        <CursorPos X="58" Y="1190"/>
+        <TopLine Value="231"/>
+        <CursorPos X="34" Y="240"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -431,123 +431,123 @@
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="179" Column="7" TopLine="145"/>
+        <Caret Line="925" Column="42" TopLine="905"/>
       </Position1>
       <Position2>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3058" Column="15" TopLine="3045"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1014" Column="28" TopLine="994"/>
       </Position2>
       <Position3>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3745" Column="87" TopLine="3716"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1029" Column="72" TopLine="1009"/>
       </Position3>
       <Position4>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="488" Column="42" TopLine="471"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1703" Column="33" TopLine="1683"/>
       </Position4>
       <Position5>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="1927" Column="75" TopLine="1899"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1704" Column="52" TopLine="1684"/>
       </Position5>
       <Position6>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="465" TopLine="431"/>
+        <Caret Line="1707" Column="52" TopLine="1687"/>
       </Position6>
       <Position7>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1088" Column="30" TopLine="1080"/>
+        <Caret Line="1710" Column="52" TopLine="1690"/>
       </Position7>
       <Position8>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1145" Column="85" TopLine="1128"/>
+        <Caret Line="1729" Column="39" TopLine="1709"/>
       </Position8>
       <Position9>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="107" Column="36" TopLine="90"/>
+        <Caret Line="1746" Column="44" TopLine="1726"/>
       </Position9>
       <Position10>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1145" Column="93" TopLine="1117"/>
+        <Caret Line="1774" Column="47" TopLine="1754"/>
       </Position10>
       <Position11>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="135" Column="19" TopLine="101"/>
+        <Caret Line="1783" Column="33" TopLine="1763"/>
       </Position11>
       <Position12>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1137" Column="82" TopLine="1117"/>
+        <Caret Line="88" Column="14" TopLine="77"/>
       </Position12>
       <Position13>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1219" Column="18" TopLine="1193"/>
+        <Caret Line="102" Column="24" TopLine="82"/>
       </Position13>
       <Position14>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="135" Column="34" TopLine="117"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="2456" TopLine="2431"/>
       </Position14>
       <Position15>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1137" Column="110" TopLine="1109"/>
+        <Caret Line="220" Column="22" TopLine="216"/>
       </Position15>
       <Position16>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="259" Column="15" TopLine="252"/>
+        <Caret Line="82" Column="12" TopLine="71"/>
       </Position16>
       <Position17>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1113" Column="10" TopLine="1083"/>
+        <Caret Line="83" Column="12" TopLine="71"/>
       </Position17>
       <Position18>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1112" Column="87" TopLine="1095"/>
+        <Caret Line="101" Column="22" TopLine="81"/>
       </Position18>
       <Position19>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1139" Column="76" TopLine="1122"/>
+        <Caret Line="283" Column="11" TopLine="263"/>
       </Position19>
       <Position20>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1147" Column="82" TopLine="1122"/>
+        <Caret Line="1004" Column="28" TopLine="984"/>
       </Position20>
       <Position21>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="77" Column="21" TopLine="60"/>
+        <Caret Line="1016" Column="11" TopLine="996"/>
       </Position21>
       <Position22>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="99" Column="31" TopLine="71"/>
+        <Caret Line="1036" Column="20" TopLine="1016"/>
       </Position22>
       <Position23>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="227" Column="49" TopLine="198"/>
+        <Caret Line="1092" Column="10" TopLine="1072"/>
       </Position23>
       <Position24>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="780" Column="25" TopLine="751"/>
+        <Caret Line="1154" Column="17" TopLine="1134"/>
       </Position24>
       <Position25>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="787" Column="24" TopLine="758"/>
+        <Caret Line="1264" Column="19" TopLine="1244"/>
       </Position25>
       <Position26>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="796" Column="24" TopLine="767"/>
+        <Caret Line="1326" Column="19" TopLine="1306"/>
       </Position26>
       <Position27>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="804" Column="24" TopLine="776"/>
+        <Caret Line="1337" Column="23" TopLine="1317"/>
       </Position27>
       <Position28>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1077" Column="40" TopLine="1049"/>
+        <Caret Line="1588" Column="40" TopLine="1568"/>
       </Position28>
       <Position29>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1112" Column="73" TopLine="1084"/>
+        <Caret Line="1604" Column="7" TopLine="1584"/>
       </Position29>
       <Position30>
         <Filename Value="diskmodule.pas"/>
-        <Caret Line="1118" Column="61" TopLine="1111"/>
+        <Caret Line="117" Column="38" TopLine="94"/>
       </Position30>
     </JumpHistory>
   </ProjectOptions>
@@ -571,6 +571,7 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
+        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
         <StripSymbols Value="True"/>
       </Debugging>

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -92,8 +92,8 @@
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="Unit2"/>
         <IsVisibleTab Value="True"/>
-        <TopLine Value="3701"/>
-        <CursorPos X="7" Y="3703"/>
+        <TopLine Value="2239"/>
+        <CursorPos X="3" Y="2262"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -431,123 +431,123 @@
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2875" Column="37" TopLine="2855"/>
+        <Caret Line="582" Column="58" TopLine="563"/>
       </Position1>
       <Position2>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3148" Column="47" TopLine="3128"/>
+        <Caret Line="957" Column="39" TopLine="937"/>
       </Position2>
       <Position3>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3158" Column="47" TopLine="3138"/>
+        <Caret Line="1085" Column="41" TopLine="1065"/>
       </Position3>
       <Position4>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3290" Column="35" TopLine="3270"/>
+        <Caret Line="1824" Column="32" TopLine="1804"/>
       </Position4>
       <Position5>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3314" Column="46" TopLine="3294"/>
+        <Caret Line="1837" Column="38" TopLine="1818"/>
       </Position5>
       <Position6>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3317" Column="46" TopLine="3297"/>
+        <Caret Line="1900" Column="38" TopLine="1880"/>
       </Position6>
       <Position7>
         <Filename Value="unit2.pas"/>
-        <Caret Line="582" Column="58" TopLine="563"/>
+        <Caret Line="1910" Column="43" TopLine="1890"/>
       </Position7>
       <Position8>
         <Filename Value="unit2.pas"/>
-        <Caret Line="957" Column="39" TopLine="937"/>
+        <Caret Line="2814" Column="35" TopLine="2794"/>
       </Position8>
       <Position9>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1085" Column="41" TopLine="1065"/>
+        <Caret Line="2880" Column="37" TopLine="2860"/>
       </Position9>
       <Position10>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1824" Column="32" TopLine="1804"/>
+        <Caret Line="3153" Column="47" TopLine="3133"/>
       </Position10>
       <Position11>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1837" Column="38" TopLine="1818"/>
+        <Caret Line="3163" Column="47" TopLine="3143"/>
       </Position11>
       <Position12>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1900" Column="38" TopLine="1880"/>
+        <Caret Line="3295" Column="35" TopLine="3275"/>
       </Position12>
       <Position13>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1910" Column="43" TopLine="1890"/>
+        <Caret Line="3319" Column="46" TopLine="3299"/>
       </Position13>
       <Position14>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2814" Column="35" TopLine="2794"/>
+        <Caret Line="3322" Column="46" TopLine="3302"/>
       </Position14>
       <Position15>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2880" Column="37" TopLine="2860"/>
+        <Caret Line="3517" Column="5" TopLine="3500"/>
       </Position15>
       <Position16>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3153" Column="47" TopLine="3133"/>
+        <Caret Line="578" Column="37" TopLine="573"/>
       </Position16>
       <Position17>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3163" Column="47" TopLine="3143"/>
+        <Caret Line="580" Column="29" TopLine="568"/>
       </Position17>
       <Position18>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3295" Column="35" TopLine="3275"/>
+        <Caret Line="3505" Column="41" TopLine="3501"/>
       </Position18>
       <Position19>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3319" Column="46" TopLine="3299"/>
+        <Caret Line="525" Column="30" TopLine="514"/>
       </Position19>
       <Position20>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3322" Column="46" TopLine="3302"/>
+        <Caret Line="580" Column="37" TopLine="560"/>
       </Position20>
       <Position21>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3517" Column="5" TopLine="3500"/>
+        <Caret Line="3505" Column="36" TopLine="3490"/>
       </Position21>
       <Position22>
         <Filename Value="unit2.pas"/>
-        <Caret Line="578" Column="37" TopLine="573"/>
+        <Caret Line="525" Column="30" TopLine="514"/>
       </Position22>
       <Position23>
         <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="29" TopLine="568"/>
+        <Caret Line="582" Column="17" TopLine="570"/>
       </Position23>
       <Position24>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3505" Column="41" TopLine="3501"/>
+        <Caret Line="580" Column="28" TopLine="570"/>
       </Position24>
       <Position25>
         <Filename Value="unit2.pas"/>
-        <Caret Line="525" Column="30" TopLine="514"/>
+        <Caret Line="3703" Column="7" TopLine="3701"/>
       </Position25>
       <Position26>
         <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="37" TopLine="560"/>
+        <Caret Line="2407" Column="3" TopLine="2405"/>
       </Position26>
       <Position27>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3505" Column="36" TopLine="3490"/>
+        <Caret Line="2265" Column="35" TopLine="2262"/>
       </Position27>
       <Position28>
         <Filename Value="unit2.pas"/>
-        <Caret Line="525" Column="30" TopLine="514"/>
+        <Caret Line="2411" Column="79" TopLine="2406"/>
       </Position28>
       <Position29>
         <Filename Value="unit2.pas"/>
-        <Caret Line="582" Column="17" TopLine="570"/>
+        <Caret Line="2248" Column="29" TopLine="2241"/>
       </Position29>
       <Position30>
         <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="28" TopLine="570"/>
+        <Caret Line="2411" Column="3" TopLine="2409"/>
       </Position30>
     </JumpHistory>
   </ProjectOptions>

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -91,9 +91,8 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="Unit2"/>
-        <IsVisibleTab Value="True"/>
-        <TopLine Value="3044"/>
-        <CursorPos X="4" Y="3076"/>
+        <TopLine Value="2431"/>
+        <CursorPos Y="2456"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -253,9 +252,10 @@
         <ComponentName Value="frmDiskHashingModule"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
+        <IsVisibleTab Value="True"/>
         <EditorIndex Value="3"/>
-        <TopLine Value="703"/>
-        <CursorPos X="17" Y="715"/>
+        <TopLine Value="1163"/>
+        <CursorPos X="58" Y="1190"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -367,7 +367,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="4"/>
         <CursorPos X="53" Y="16"/>
-        <UsageCount Value="159"/>
+        <UsageCount Value="161"/>
       </Unit38>
       <Unit39>
         <Filename Value="uloadhashlist.pas"/>
@@ -375,14 +375,14 @@
         <UnitName Value="uLoadhashlist"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21"/>
-        <UsageCount Value="157"/>
+        <UsageCount Value="159"/>
       </Unit39>
       <Unit40>
         <Filename Value="uKnownHashLists.pas"/>
         <EditorIndex Value="1"/>
         <TopLine Value="24"/>
         <CursorPos X="6" Y="48"/>
-        <UsageCount Value="75"/>
+        <UsageCount Value="76"/>
         <Loaded Value="True"/>
       </Unit40>
       <Unit41>
@@ -430,124 +430,124 @@
     </Units>
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="1837" Column="38" TopLine="1818"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="179" Column="7" TopLine="145"/>
       </Position1>
       <Position2>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1900" Column="38" TopLine="1880"/>
+        <Caret Line="3058" Column="15" TopLine="3045"/>
       </Position2>
       <Position3>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1910" Column="43" TopLine="1890"/>
+        <Caret Line="3745" Column="87" TopLine="3716"/>
       </Position3>
       <Position4>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2814" Column="35" TopLine="2794"/>
+        <Caret Line="488" Column="42" TopLine="471"/>
       </Position4>
       <Position5>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2880" Column="37" TopLine="2860"/>
+        <Caret Line="1927" Column="75" TopLine="1899"/>
       </Position5>
       <Position6>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3153" Column="47" TopLine="3133"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="465" TopLine="431"/>
       </Position6>
       <Position7>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3163" Column="47" TopLine="3143"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1088" Column="30" TopLine="1080"/>
       </Position7>
       <Position8>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3295" Column="35" TopLine="3275"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1145" Column="85" TopLine="1128"/>
       </Position8>
       <Position9>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3319" Column="46" TopLine="3299"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="107" Column="36" TopLine="90"/>
       </Position9>
       <Position10>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3322" Column="46" TopLine="3302"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1145" Column="93" TopLine="1117"/>
       </Position10>
       <Position11>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3517" Column="5" TopLine="3500"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="135" Column="19" TopLine="101"/>
       </Position11>
       <Position12>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="578" Column="37" TopLine="573"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1137" Column="82" TopLine="1117"/>
       </Position12>
       <Position13>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="29" TopLine="568"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1219" Column="18" TopLine="1193"/>
       </Position13>
       <Position14>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3505" Column="41" TopLine="3501"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="135" Column="34" TopLine="117"/>
       </Position14>
       <Position15>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="525" Column="30" TopLine="514"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1137" Column="110" TopLine="1109"/>
       </Position15>
       <Position16>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="37" TopLine="560"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="259" Column="15" TopLine="252"/>
       </Position16>
       <Position17>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3505" Column="36" TopLine="3490"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1113" Column="10" TopLine="1083"/>
       </Position17>
       <Position18>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="525" Column="30" TopLine="514"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1112" Column="87" TopLine="1095"/>
       </Position18>
       <Position19>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="582" Column="17" TopLine="570"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1139" Column="76" TopLine="1122"/>
       </Position19>
       <Position20>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="28" TopLine="570"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1147" Column="82" TopLine="1122"/>
       </Position20>
       <Position21>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="3703" Column="7" TopLine="3701"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="77" Column="21" TopLine="60"/>
       </Position21>
       <Position22>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2407" Column="3" TopLine="2405"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="99" Column="31" TopLine="71"/>
       </Position22>
       <Position23>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2265" Column="35" TopLine="2262"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="227" Column="49" TopLine="198"/>
       </Position23>
       <Position24>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2411" Column="79" TopLine="2406"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="780" Column="25" TopLine="751"/>
       </Position24>
       <Position25>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2248" Column="29" TopLine="2241"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="787" Column="24" TopLine="758"/>
       </Position25>
       <Position26>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2411" Column="3" TopLine="2409"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="796" Column="24" TopLine="767"/>
       </Position26>
       <Position27>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2262" Column="3" TopLine="2239"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="804" Column="24" TopLine="776"/>
       </Position27>
       <Position28>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2422" Column="3" TopLine="2420"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1077" Column="40" TopLine="1049"/>
       </Position28>
       <Position29>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2952" Column="3" TopLine="2947"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1112" Column="73" TopLine="1084"/>
       </Position29>
       <Position30>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2422" Column="12" TopLine="2420"/>
+        <Filename Value="diskmodule.pas"/>
+        <Caret Line="1118" Column="61" TopLine="1111"/>
       </Position30>
     </JumpHistory>
   </ProjectOptions>

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -54,11 +54,11 @@
         <PackageName Value="LCL"/>
       </Item6>
     </RequiredPackages>
-    <Units Count="77">
+    <Units Count="79">
       <Unit0>
         <Filename Value="quickhash.lpr"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="7"/>
+        <EditorIndex Value="9"/>
         <TopLine Value="84"/>
         <CursorPos Y="95"/>
         <UsageCount Value="200"/>
@@ -99,8 +99,8 @@
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="Unit2"/>
         <IsVisibleTab Value="True"/>
-        <TopLine Value="1299"/>
-        <CursorPos X="7" Y="1329"/>
+        <TopLine Value="2587"/>
+        <CursorPos X="102" Y="2611"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -227,7 +227,7 @@
       </Unit24>
       <Unit25>
         <Filename Value="FindAllFilesEnhanced.pas"/>
-        <EditorIndex Value="6"/>
+        <EditorIndex Value="8"/>
         <CursorPos X="4" Y="10"/>
         <UsageCount Value="100"/>
         <Loaded Value="True"/>
@@ -268,7 +268,7 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="uDisplayGrid"/>
-        <EditorIndex Value="5"/>
+        <EditorIndex Value="7"/>
         <CursorPos X="27" Y="6"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
@@ -417,7 +417,7 @@
         <ComponentName Value="frmDiskHashingModule"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="3"/>
+        <EditorIndex Value="5"/>
         <CursorPos X="32" Y="11"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
@@ -479,7 +479,7 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="uProgress"/>
-        <EditorIndex Value="4"/>
+        <EditorIndex Value="6"/>
         <CursorPos X="17"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
@@ -505,8 +505,9 @@
         <ComponentName Value="frmSQLiteDBases"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="2"/>
-        <CursorPos X="31" Y="22"/>
+        <EditorIndex Value="4"/>
+        <TopLine Value="1137"/>
+        <CursorPos X="22" Y="1153"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -559,9 +560,9 @@
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="frmAboutUnit"/>
-        <EditorIndex Value="8"/>
+        <EditorIndex Value="10"/>
         <CursorPos X="9" Y="15"/>
-        <UsageCount Value="60"/>
+        <UsageCount Value="61"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
       </Unit66>
@@ -592,7 +593,7 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="4"/>
         <CursorPos X="53" Y="16"/>
-        <UsageCount Value="77"/>
+        <UsageCount Value="79"/>
       </Unit70>
       <Unit71>
         <Filename Value="uloadhashlist.pas"/>
@@ -600,14 +601,14 @@
         <UnitName Value="uLoadhashlist"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21"/>
-        <UsageCount Value="75"/>
+        <UsageCount Value="77"/>
       </Unit71>
       <Unit72>
         <Filename Value="uKnownHashLists.pas"/>
-        <EditorIndex Value="1"/>
+        <EditorIndex Value="3"/>
         <TopLine Value="24"/>
         <CursorPos X="6" Y="48"/>
-        <UsageCount Value="34"/>
+        <UsageCount Value="35"/>
         <Loaded Value="True"/>
       </Unit72>
       <Unit73>
@@ -638,127 +639,143 @@
         <CursorPos X="3" Y="14"/>
         <UsageCount Value="10"/>
       </Unit76>
+      <Unit77>
+        <Filename Value="/usr/local/share/fpcsrc/rtl/objpas/classes/classesh.inc"/>
+        <EditorIndex Value="1"/>
+        <TopLine Value="922"/>
+        <CursorPos X="17" Y="938"/>
+        <UsageCount Value="10"/>
+        <Loaded Value="True"/>
+      </Unit77>
+      <Unit78>
+        <Filename Value="/usr/local/share/fpcsrc/rtl/inc/objpash.inc"/>
+        <EditorIndex Value="2"/>
+        <TopLine Value="177"/>
+        <CursorPos X="23" Y="193"/>
+        <UsageCount Value="10"/>
+        <Loaded Value="True"/>
+      </Unit78>
     </Units>
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="455" Column="16" TopLine="432"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="3504" Column="18" TopLine="3488"/>
       </Position1>
       <Position2>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="456" Column="53" TopLine="433"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="3495" Column="14" TopLine="3488"/>
       </Position2>
       <Position3>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="457" Column="16" TopLine="434"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1045" Column="40" TopLine="1031"/>
       </Position3>
       <Position4>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="461" Column="16" TopLine="438"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1080" Column="42" TopLine="1054"/>
       </Position4>
       <Position5>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="463" Column="23" TopLine="440"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1819" Column="33" TopLine="1792"/>
       </Position5>
       <Position6>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="563" Column="34" TopLine="539"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1832" Column="39" TopLine="1805"/>
       </Position6>
       <Position7>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="578" Column="61" TopLine="554"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1895" Column="39" TopLine="1869"/>
       </Position7>
       <Position8>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="595" Column="34" TopLine="571"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1905" Column="44" TopLine="1879"/>
       </Position8>
       <Position9>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="619" Column="79" TopLine="595"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="2809" Column="36" TopLine="2783"/>
       </Position9>
       <Position10>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1021" Column="23" TopLine="997"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1108" Column="23" TopLine="1097"/>
       </Position10>
       <Position11>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1022" Column="16" TopLine="998"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1819" Column="33" TopLine="1792"/>
       </Position11>
       <Position12>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1025" Column="23" TopLine="1001"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1832" Column="39" TopLine="1805"/>
       </Position12>
       <Position13>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1026" Column="23" TopLine="1002"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1895" Column="39" TopLine="1869"/>
       </Position13>
       <Position14>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1027" Column="46" TopLine="1003"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1905" Column="44" TopLine="1879"/>
       </Position14>
       <Position15>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1028" Column="23" TopLine="1004"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="2809" Column="36" TopLine="2783"/>
       </Position15>
       <Position16>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1030" Column="16" TopLine="1006"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="2875" Column="38" TopLine="2849"/>
       </Position16>
       <Position17>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1031" Column="53" TopLine="1007"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="3148" Column="48" TopLine="3122"/>
       </Position17>
       <Position18>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1033" Column="49" TopLine="1009"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="3158" Column="48" TopLine="3132"/>
       </Position18>
       <Position19>
-        <Filename Value="diskmodule.pas"/>
-        <Caret Line="1037" Column="16" TopLine="1013"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="3290" Column="36" TopLine="3263"/>
       </Position19>
       <Position20>
         <Filename Value="unit2.pas"/>
-        <Caret Line="56" Column="39" TopLine="52"/>
+        <Caret Line="3314" Column="47" TopLine="3287"/>
       </Position20>
       <Position21>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2035" Column="16" TopLine="2013"/>
+        <Caret Line="3317" Column="47" TopLine="3290"/>
       </Position21>
       <Position22>
         <Filename Value="unit2.pas"/>
-        <Caret Line="103" Column="3" TopLine="86"/>
+        <Caret Line="3489" Column="93" TopLine="3485"/>
       </Position22>
       <Position23>
-        <Filename Value="uKnownHashLists.pas"/>
-        <Caret Line="9" Column="27"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="1264" Column="59" TopLine="1248"/>
       </Position23>
       <Position24>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1146" Column="20" TopLine="1113"/>
+        <Caret Line="1268" Column="32" TopLine="1248"/>
       </Position24>
       <Position25>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2039" Column="5" TopLine="2013"/>
+        <Caret Line="100" Column="83" TopLine="84"/>
       </Position25>
       <Position26>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2380" Column="30" TopLine="2352"/>
+        <Filename Value="dbases_sqlite.pas"/>
+        <Caret Line="114" Column="3" TopLine="98"/>
       </Position26>
       <Position27>
-        <Filename Value="unit2.pas"/>
-        <Caret Line="2372" Column="6" TopLine="2361"/>
+        <Filename Value="dbases_sqlite.pas"/>
+        <Caret Line="374" Column="70" TopLine="372"/>
       </Position27>
       <Position28>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2036" Column="53" TopLine="2013"/>
+        <Caret Line="2613" TopLine="2597"/>
       </Position28>
       <Position29>
-        <Filename Value="quickhash.lpr"/>
-        <Caret Line="95" TopLine="80"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="4140" Column="128" TopLine="4114"/>
       </Position29>
       <Position30>
-        <Filename Value="quickhash.lpr"/>
-        <Caret Line="105" TopLine="84"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="369" Column="8" TopLine="354"/>
       </Position30>
     </JumpHistory>
   </ProjectOptions>

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -54,13 +54,13 @@
         <PackageName Value="LCL"/>
       </Item6>
     </RequiredPackages>
-    <Units Count="79">
+    <Units Count="47">
       <Unit0>
         <Filename Value="quickhash.lpr"/>
         <IsPartOfProject Value="True"/>
-        <EditorIndex Value="9"/>
-        <TopLine Value="84"/>
-        <CursorPos Y="95"/>
+        <EditorIndex Value="7"/>
+        <TopLine Value="74"/>
+        <CursorPos X="34" Y="85"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
       </Unit0>
@@ -71,27 +71,21 @@
         <ResourceBaseClass Value="Form"/>
         <TopLine Value="1353"/>
         <CursorPos X="25" Y="777"/>
-        <UsageCount Value="156"/>
+        <UsageCount Value="148"/>
       </Unit1>
       <Unit2>
         <Filename Value="../../../lazarus/lcl/grids.pas"/>
         <TopLine Value="1081"/>
         <CursorPos X="22" Y="1106"/>
-        <UsageCount Value="253"/>
+        <UsageCount Value="245"/>
       </Unit2>
       <Unit3>
         <Filename Value="../AmazonUtil/unit1.pas"/>
         <TopLine Value="210"/>
         <CursorPos X="7" Y="240"/>
-        <UsageCount Value="250"/>
+        <UsageCount Value="242"/>
       </Unit3>
       <Unit4>
-        <Filename Value="../RoastLamb - Alpha 8.0 - Distributed 12-11-29/unit1.pas"/>
-        <TopLine Value="3047"/>
-        <CursorPos X="57" Y="3077"/>
-        <UsageCount Value="2"/>
-      </Unit4>
-      <Unit5>
         <Filename Value="unit2.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="MainForm"/>
@@ -99,94 +93,94 @@
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="Unit2"/>
         <IsVisibleTab Value="True"/>
-        <TopLine Value="2587"/>
-        <CursorPos X="102" Y="2611"/>
+        <TopLine Value="3701"/>
+        <CursorPos X="7" Y="3703"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit5>
-      <Unit6>
+      </Unit4>
+      <Unit5>
         <Filename Value="../dcpcrypt-2.0.4.1/dcpcrypt2.pas"/>
         <TopLine Value="299"/>
         <CursorPos X="46" Y="306"/>
-        <UsageCount Value="8"/>
-      </Unit6>
-      <Unit7>
+        <UsageCount Value="10"/>
+      </Unit5>
+      <Unit6>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcphaval.pas"/>
         <TopLine Value="275"/>
         <CursorPos X="54" Y="299"/>
-        <UsageCount Value="8"/>
-      </Unit7>
-      <Unit8>
+        <UsageCount Value="10"/>
+      </Unit6>
+      <Unit7>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpmd4.pas"/>
         <TopLine Value="168"/>
         <CursorPos X="52" Y="192"/>
-        <UsageCount Value="8"/>
-      </Unit8>
-      <Unit9>
+        <UsageCount Value="10"/>
+      </Unit7>
+      <Unit8>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpmd5.pas"/>
         <TopLine Value="185"/>
         <CursorPos X="52" Y="209"/>
-        <UsageCount Value="8"/>
-      </Unit9>
-      <Unit10>
+        <UsageCount Value="10"/>
+      </Unit8>
+      <Unit9>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpripemd128.pas"/>
         <TopLine Value="251"/>
         <CursorPos X="58" Y="275"/>
-        <UsageCount Value="8"/>
-      </Unit10>
-      <Unit11>
+        <UsageCount Value="10"/>
+      </Unit9>
+      <Unit10>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpripemd160.pas"/>
         <TopLine Value="612"/>
         <CursorPos X="58" Y="636"/>
-        <UsageCount Value="8"/>
-      </Unit11>
-      <Unit12>
+        <UsageCount Value="10"/>
+      </Unit10>
+      <Unit11>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpsha1.pas"/>
         <TopLine Value="204"/>
         <CursorPos X="53" Y="228"/>
-        <UsageCount Value="8"/>
-      </Unit12>
-      <Unit13>
+        <UsageCount Value="10"/>
+      </Unit11>
+      <Unit12>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpsha256.pas"/>
         <TopLine Value="10"/>
         <CursorPos Y="10"/>
-        <UsageCount Value="8"/>
-      </Unit13>
-      <Unit14>
+        <UsageCount Value="10"/>
+      </Unit12>
+      <Unit13>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcpsha512.pas"/>
         <TopLine Value="185"/>
         <CursorPos X="59" Y="209"/>
-        <UsageCount Value="8"/>
-      </Unit14>
-      <Unit15>
+        <UsageCount Value="10"/>
+      </Unit13>
+      <Unit14>
         <Filename Value="../dcpcrypt-2.0.4.1/Hashes/dcptiger.pas"/>
         <TopLine Value="231"/>
         <CursorPos X="26" Y="265"/>
-        <UsageCount Value="8"/>
-      </Unit15>
-      <Unit16>
+        <UsageCount Value="10"/>
+      </Unit14>
+      <Unit15>
         <Filename Value="sha1customised.pas"/>
         <UnitName Value="sha1Customised"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="297"/>
         <CursorPos X="18" Y="303"/>
-        <UsageCount Value="187"/>
-      </Unit16>
-      <Unit17>
+        <UsageCount Value="179"/>
+      </Unit15>
+      <Unit16>
         <Filename Value="md5customised.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="611"/>
         <CursorPos X="87" Y="632"/>
-        <UsageCount Value="187"/>
-      </Unit17>
-      <Unit18>
+        <UsageCount Value="179"/>
+      </Unit16>
+      <Unit17>
         <Filename Value="DiskModule/diskmoduleunit1.lfm"/>
         <EditorIndex Value="-1"/>
-        <UsageCount Value="61"/>
+        <UsageCount Value="53"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
-      </Unit18>
-      <Unit19>
+      </Unit17>
+      <Unit18>
         <Filename Value="DiskModule/diskmoduleunit1.pas"/>
         <ComponentName Value="frmDiskHashingModule"/>
         <HasResources Value="True"/>
@@ -195,235 +189,79 @@
         <EditorIndex Value="-1"/>
         <TopLine Value="19"/>
         <CursorPos X="47" Y="22"/>
-        <UsageCount Value="187"/>
-      </Unit19>
-      <Unit20>
+        <UsageCount Value="179"/>
+      </Unit18>
+      <Unit19>
         <Filename Value="DiskModule/sha1customised.pas"/>
         <TopLine Value="10"/>
         <CursorPos X="41" Y="267"/>
-        <UsageCount Value="8"/>
-      </Unit20>
-      <Unit21>
-        <Filename Value="/lazarus/fpc/2.6.4/source/rtl/objpas/sysutils/filutilh.inc"/>
-        <TopLine Value="63"/>
-        <CursorPos X="10" Y="88"/>
-        <UsageCount Value="4"/>
-      </Unit21>
-      <Unit22>
+        <UsageCount Value="10"/>
+      </Unit19>
+      <Unit20>
         <Filename Value="Tmp-ScrShots/forforum.pas"/>
         <TopLine Value="91"/>
         <CursorPos X="79" Y="132"/>
-        <UsageCount Value="185"/>
-      </Unit22>
-      <Unit23>
+        <UsageCount Value="177"/>
+      </Unit20>
+      <Unit21>
         <Filename Value="/lazarus/fpc/2.6.4/source/rtl/objpas/types.pp"/>
         <TopLine Value="105"/>
-        <UsageCount Value="8"/>
-      </Unit23>
-      <Unit24>
+        <UsageCount Value="10"/>
+      </Unit21>
+      <Unit22>
         <Filename Value="findallfilesenhancedunit.pas"/>
         <CursorPos X="43" Y="15"/>
-        <UsageCount Value="182"/>
-      </Unit24>
-      <Unit25>
+        <UsageCount Value="174"/>
+      </Unit22>
+      <Unit23>
         <Filename Value="FindAllFilesEnhanced.pas"/>
-        <EditorIndex Value="8"/>
+        <EditorIndex Value="6"/>
         <CursorPos X="4" Y="10"/>
         <UsageCount Value="100"/>
         <Loaded Value="True"/>
-      </Unit25>
-      <Unit26>
-        <Filename Value="/usr/share/lazarus/1.2.6/lcl/include/control.inc"/>
-        <TopLine Value="2698"/>
-        <CursorPos Y="2722"/>
-        <UsageCount Value="1"/>
-      </Unit26>
-      <Unit27>
-        <Filename Value="/usr/share/lazarus/1.2.6/components/lazutils/fileutil.pas"/>
-        <TopLine Value="141"/>
-        <CursorPos X="5" Y="165"/>
-        <UsageCount Value="1"/>
-      </Unit27>
-      <Unit28>
-        <Filename Value="/lazarus/components/lazutils/fileutil.pas"/>
-        <TopLine Value="154"/>
-        <CursorPos X="3" Y="191"/>
-        <UsageCount Value="2"/>
-      </Unit28>
-      <Unit29>
-        <Filename Value="unit2.lrs"/>
-        <CursorPos X="868" Y="383"/>
-        <UsageCount Value="2"/>
-      </Unit29>
-      <Unit30>
-        <Filename Value="/lazarus/lcl/grids.pas"/>
-        <TopLine Value="10446"/>
-        <CursorPos X="22" Y="10477"/>
-        <UsageCount Value="2"/>
-      </Unit30>
-      <Unit31>
+      </Unit23>
+      <Unit24>
         <Filename Value="udisplaygrid.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="frmDisplayGrid1"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="uDisplayGrid"/>
-        <EditorIndex Value="7"/>
+        <EditorIndex Value="5"/>
         <CursorPos X="27" Y="6"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit31>
-      <Unit32>
-        <Filename Value="/lazarus/fpc/2.6.4/source/rtl/inc/wstringh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="7"/>
-        <CursorPos X="10" Y="24"/>
-        <UsageCount Value="2"/>
-      </Unit32>
-      <Unit33>
-        <Filename Value="/lazarus/fpc/2.6.4/source/rtl/inc/wstrings.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="922"/>
-        <CursorPos X="5" Y="947"/>
-        <UsageCount Value="2"/>
-      </Unit33>
-      <Unit34>
-        <Filename Value="/lazarus/fpc/2.6.4/source/rtl/objpas/sysutils/sysstrh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="201"/>
-        <CursorPos X="15" Y="218"/>
-        <UsageCount Value="1"/>
-      </Unit34>
-      <Unit35>
-        <Filename Value="/lazarus/fpc/2.6.4/source/rtl/objpas/sysutils/sysstr.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="2620"/>
-        <CursorPos X="15" Y="2645"/>
-        <UsageCount Value="1"/>
-      </Unit35>
-      <Unit36>
+      </Unit24>
+      <Unit25>
         <Filename Value="/usr/share/lazarus/1.4.4/components/lazutils/fileutil.pas"/>
         <UnitName Value="FileUtil"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="159"/>
         <CursorPos X="15" Y="170"/>
-        <UsageCount Value="8"/>
-      </Unit36>
-      <Unit37>
-        <Filename Value="/lazarus/fpc/2.6.4/source/rtl/inc/systemh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="998"/>
-        <CursorPos X="11" Y="1015"/>
-        <UsageCount Value="1"/>
-      </Unit37>
-      <Unit38>
-        <Filename Value="/lazarus-FPC3/fpc/3.0.0/source/rtl/objpas/classes/classesh.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="899"/>
-        <CursorPos X="17" Y="926"/>
-        <UsageCount Value="2"/>
-      </Unit38>
-      <Unit39>
-        <Filename Value="/lazarus-FPC3/fpc/3.0.0/source/rtl/inc/objpash.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="166"/>
-        <CursorPos X="25" Y="193"/>
-        <UsageCount Value="2"/>
-      </Unit39>
-      <Unit40>
+        <UsageCount Value="10"/>
+      </Unit25>
+      <Unit26>
         <Filename Value="/lazarus-FPC3/fpc/3.0.0/source/rtl/inc/objpas.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="275"/>
         <CursorPos X="9" Y="277"/>
-        <UsageCount Value="8"/>
-      </Unit40>
-      <Unit41>
-        <Filename Value="/usr/share/lazarus/1.6.2/lcl/grids.pas"/>
-        <UnitName Value="Grids"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="9259"/>
-        <CursorPos Y="9287"/>
-        <UsageCount Value="6"/>
-      </Unit41>
-      <Unit42>
-        <Filename Value="/usr/share/lazarus/1.6.2/lcl/dynamicarray.pas"/>
-        <UnitName Value="DynamicArray"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="34"/>
-        <CursorPos Y="69"/>
-        <UsageCount Value="6"/>
-      </Unit42>
-      <Unit43>
-        <Filename Value="/usr/share/lazarus/1.6.2/lcl/include/wincontrol.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="7325"/>
-        <CursorPos Y="7354"/>
-        <UsageCount Value="6"/>
-      </Unit43>
-      <Unit44>
-        <Filename Value="/usr/share/lazarus/1.6.2/lcl/include/control.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="3414"/>
-        <CursorPos Y="3442"/>
-        <UsageCount Value="6"/>
-      </Unit44>
-      <Unit45>
-        <Filename Value="utilwmi.pas"/>
-        <UnitName Value="Utilwmi"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="102"/>
-        <CursorPos X="4" Y="73"/>
-        <UsageCount Value="4"/>
-      </Unit45>
-      <Unit46>
-        <Filename Value="DiskModule/DiskModuleNew/diskmodule.pas"/>
-        <ComponentName Value="frmDiskHashingModule"/>
-        <HasResources Value="True"/>
-        <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="32" Y="49"/>
-        <UsageCount Value="3"/>
-      </Unit46>
-      <Unit47>
-        <Filename Value="DiskModule/DiskModuleNew/uprogress.pas"/>
-        <ComponentName Value="frmProgress"/>
-        <HasResources Value="True"/>
-        <ResourceBaseClass Value="Form"/>
-        <UnitName Value="uProgress"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="24" Y="14"/>
-        <UsageCount Value="2"/>
-      </Unit47>
-      <Unit48>
-        <Filename Value="DiskModule/DiskModuleNew/diskspecification.pas"/>
-        <ComponentName Value="frmTechSpecs"/>
-        <HasResources Value="True"/>
-        <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="34" Y="12"/>
-        <UsageCount Value="2"/>
-      </Unit48>
-      <Unit49>
-        <Filename Value="/usr/share/lazarus/1.6.2/lcl/include/customform.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="2180"/>
-        <CursorPos Y="2208"/>
-        <UsageCount Value="2"/>
-      </Unit49>
-      <Unit50>
+        <UsageCount Value="10"/>
+      </Unit26>
+      <Unit27>
         <Filename Value="diskmodule.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="frmDiskHashingModule"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="5"/>
-        <CursorPos X="32" Y="11"/>
+        <EditorIndex Value="3"/>
+        <TopLine Value="703"/>
+        <CursorPos X="17" Y="715"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit50>
-      <Unit51>
+      </Unit27>
+      <Unit28>
         <Filename Value="diskmodule.lfm"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="-1"/>
@@ -432,8 +270,8 @@
         <CursorPos X="-1" Y="-1"/>
         <UsageCount Value="200"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
-      </Unit51>
-      <Unit52>
+      </Unit28>
+      <Unit29>
         <Filename Value="diskspecification.lfm"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="-1"/>
@@ -442,8 +280,8 @@
         <CursorPos X="-1" Y="-1"/>
         <UsageCount Value="200"/>
         <DefaultSyntaxHighlighter Value="LFM"/>
-      </Unit52>
-      <Unit53>
+      </Unit29>
+      <Unit30>
         <Filename Value="diskspecification.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="frmTechSpecs"/>
@@ -453,8 +291,8 @@
         <TopLine Value="12"/>
         <CursorPos X="3" Y="26"/>
         <UsageCount Value="200"/>
-      </Unit53>
-      <Unit54>
+      </Unit30>
+      <Unit31>
         <Filename Value="GPTMBR.pas"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="-1"/>
@@ -462,8 +300,8 @@
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
         <UsageCount Value="200"/>
-      </Unit54>
-      <Unit55>
+      </Unit31>
+      <Unit32>
         <Filename Value="uGPT.pas"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="-1"/>
@@ -471,311 +309,246 @@
         <TopLine Value="-1"/>
         <CursorPos X="-1" Y="-1"/>
         <UsageCount Value="200"/>
-      </Unit55>
-      <Unit56>
+      </Unit32>
+      <Unit33>
         <Filename Value="uprogress.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="frmProgress"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="uProgress"/>
-        <EditorIndex Value="6"/>
+        <EditorIndex Value="4"/>
         <CursorPos X="17"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit56>
-      <Unit57>
+      </Unit33>
+      <Unit34>
         <Filename Value="HashLib4Pascal/HashLib/src/Base/HlpHashFactory.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="92"/>
         <CursorPos X="23" Y="117"/>
-        <UsageCount Value="101"/>
-      </Unit57>
-      <Unit58>
-        <Filename Value="/usr/share/lazarus/1.6.2/lcl/include/radiogroup.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="412"/>
-        <CursorPos X="65" Y="444"/>
-        <UsageCount Value="2"/>
-      </Unit58>
-      <Unit59>
+        <UsageCount Value="93"/>
+      </Unit34>
+      <Unit35>
         <Filename Value="dbases_sqlite.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="frmSQLiteDBases"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <EditorIndex Value="4"/>
-        <TopLine Value="1137"/>
-        <CursorPos X="22" Y="1153"/>
+        <EditorIndex Value="2"/>
+        <CursorPos X="9" Y="22"/>
         <UsageCount Value="200"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit59>
-      <Unit60>
-        <Filename Value="../../../lazarus/fpc/3.0.2/source/packages/fcl-db/src/export/fpcsvexport.pp"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="45"/>
-        <CursorPos X="14" Y="64"/>
-        <UsageCount Value="6"/>
-      </Unit60>
-      <Unit61>
-        <Filename Value="../../../lazarus-FPC3/fpc/3.0.2/source/packages/fcl-db/src/base/db.pas"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="1643"/>
-        <CursorPos X="15" Y="1657"/>
-        <UsageCount Value="4"/>
-      </Unit61>
-      <Unit62>
-        <Filename Value="../../../lazarus-FPC3/fpc/3.0.2/source/packages/fcl-db/src/base/dataset.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="2054"/>
-        <CursorPos X="3" Y="2057"/>
-        <UsageCount Value="4"/>
-      </Unit62>
-      <Unit63>
-        <Filename Value="../../../lazarus-FPC3/lcl/dbgrids.pas"/>
-        <UnitName Value="DBGrids"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="960"/>
-        <CursorPos X="3" Y="518"/>
-        <UsageCount Value="3"/>
-      </Unit63>
-      <Unit64>
+      </Unit35>
+      <Unit36>
         <Filename Value="../../../lazarus/fpc/3.0.2/source/packages/fcl-db/src/base/db.pas"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1397"/>
         <CursorPos X="9" Y="1425"/>
-        <UsageCount Value="10"/>
-      </Unit64>
-      <Unit65>
-        <Filename Value="../../../lazarus/fpc/3.0.2/source/rtl/objpas/sysutils/diskh.inc"/>
-        <EditorIndex Value="-1"/>
-        <CursorPos X="10" Y="18"/>
-        <UsageCount Value="4"/>
-      </Unit65>
-      <Unit66>
+        <UsageCount Value="2"/>
+      </Unit36>
+      <Unit37>
         <Filename Value="frmaboutunit.pas"/>
         <ComponentName Value="frmAbout"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="frmAboutUnit"/>
-        <EditorIndex Value="10"/>
+        <EditorIndex Value="8"/>
+        <TopLine Value="11"/>
         <CursorPos X="9" Y="15"/>
-        <UsageCount Value="61"/>
+        <UsageCount Value="100"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
-      </Unit66>
-      <Unit67>
-        <Filename Value="/usr/share/fpcsrc/3.0.2/packages/sqlite/src/sqlite3.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="17"/>
-        <CursorPos X="3" Y="30"/>
-        <UsageCount Value="5"/>
-      </Unit67>
-      <Unit68>
-        <Filename Value="../../../lazarus/fpc/3.0.2/source/rtl/objpas/sysutils/datih.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="127"/>
-        <CursorPos X="10" Y="155"/>
-        <UsageCount Value="6"/>
-      </Unit68>
-      <Unit69>
-        <Filename Value="../../../lazarus/fpc/3.0.2/source/rtl/objpas/sysutils/dati.inc"/>
-        <EditorIndex Value="-1"/>
-        <TopLine Value="873"/>
-        <CursorPos X="3" Y="884"/>
-        <UsageCount Value="6"/>
-      </Unit69>
-      <Unit70>
+      </Unit37>
+      <Unit38>
         <Filename Value="loadhashlist.pas"/>
         <IsPartOfProject Value="True"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="4"/>
         <CursorPos X="53" Y="16"/>
-        <UsageCount Value="79"/>
-      </Unit70>
-      <Unit71>
+        <UsageCount Value="159"/>
+      </Unit38>
+      <Unit39>
         <Filename Value="uloadhashlist.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="uLoadhashlist"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="21"/>
-        <UsageCount Value="77"/>
-      </Unit71>
-      <Unit72>
+        <UsageCount Value="157"/>
+      </Unit39>
+      <Unit40>
         <Filename Value="uKnownHashLists.pas"/>
-        <EditorIndex Value="3"/>
+        <EditorIndex Value="1"/>
         <TopLine Value="24"/>
         <CursorPos X="6" Y="48"/>
-        <UsageCount Value="35"/>
+        <UsageCount Value="75"/>
         <Loaded Value="True"/>
-      </Unit72>
-      <Unit73>
+      </Unit40>
+      <Unit41>
         <Filename Value="../../../lazarus/fpc/3.0.2/source/packages/fcl-base/src/contnrs.pp"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1454"/>
         <CursorPos X="3" Y="1459"/>
-        <UsageCount Value="11"/>
-      </Unit73>
-      <Unit74>
+        <UsageCount Value="3"/>
+      </Unit41>
+      <Unit42>
         <Filename Value="../../../lazarus/components/lazutils/fileutil.pas"/>
         <UnitName Value="FileUtil"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="193"/>
         <CursorPos X="15" Y="221"/>
-        <UsageCount Value="9"/>
-      </Unit74>
-      <Unit75>
+        <UsageCount Value="1"/>
+      </Unit42>
+      <Unit43>
         <Filename Value="../../../lazarus/components/lazutils/fileutil.inc"/>
         <EditorIndex Value="-1"/>
         <TopLine Value="1191"/>
         <CursorPos X="5" Y="1241"/>
-        <UsageCount Value="9"/>
-      </Unit75>
-      <Unit76>
+        <UsageCount Value="1"/>
+      </Unit43>
+      <Unit44>
         <Filename Value="/usr/share/fpcsrc/3.0.2/packages/fcl-db/src/sqldb/sqldblib.pp"/>
         <EditorIndex Value="-1"/>
         <CursorPos X="3" Y="14"/>
-        <UsageCount Value="10"/>
-      </Unit76>
-      <Unit77>
+        <UsageCount Value="2"/>
+      </Unit44>
+      <Unit45>
         <Filename Value="/usr/local/share/fpcsrc/rtl/objpas/classes/classesh.inc"/>
-        <EditorIndex Value="1"/>
+        <EditorIndex Value="-1"/>
         <TopLine Value="922"/>
         <CursorPos X="17" Y="938"/>
-        <UsageCount Value="10"/>
-        <Loaded Value="True"/>
-      </Unit77>
-      <Unit78>
+        <UsageCount Value="2"/>
+      </Unit45>
+      <Unit46>
         <Filename Value="/usr/local/share/fpcsrc/rtl/inc/objpash.inc"/>
-        <EditorIndex Value="2"/>
+        <EditorIndex Value="-1"/>
         <TopLine Value="177"/>
         <CursorPos X="23" Y="193"/>
-        <UsageCount Value="10"/>
-        <Loaded Value="True"/>
-      </Unit78>
+        <UsageCount Value="2"/>
+      </Unit46>
     </Units>
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3504" Column="18" TopLine="3488"/>
+        <Caret Line="2875" Column="37" TopLine="2855"/>
       </Position1>
       <Position2>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3495" Column="14" TopLine="3488"/>
+        <Caret Line="3148" Column="47" TopLine="3128"/>
       </Position2>
       <Position3>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1045" Column="40" TopLine="1031"/>
+        <Caret Line="3158" Column="47" TopLine="3138"/>
       </Position3>
       <Position4>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1080" Column="42" TopLine="1054"/>
+        <Caret Line="3290" Column="35" TopLine="3270"/>
       </Position4>
       <Position5>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1819" Column="33" TopLine="1792"/>
+        <Caret Line="3314" Column="46" TopLine="3294"/>
       </Position5>
       <Position6>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1832" Column="39" TopLine="1805"/>
+        <Caret Line="3317" Column="46" TopLine="3297"/>
       </Position6>
       <Position7>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1895" Column="39" TopLine="1869"/>
+        <Caret Line="582" Column="58" TopLine="563"/>
       </Position7>
       <Position8>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1905" Column="44" TopLine="1879"/>
+        <Caret Line="957" Column="39" TopLine="937"/>
       </Position8>
       <Position9>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2809" Column="36" TopLine="2783"/>
+        <Caret Line="1085" Column="41" TopLine="1065"/>
       </Position9>
       <Position10>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1108" Column="23" TopLine="1097"/>
+        <Caret Line="1824" Column="32" TopLine="1804"/>
       </Position10>
       <Position11>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1819" Column="33" TopLine="1792"/>
+        <Caret Line="1837" Column="38" TopLine="1818"/>
       </Position11>
       <Position12>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1832" Column="39" TopLine="1805"/>
+        <Caret Line="1900" Column="38" TopLine="1880"/>
       </Position12>
       <Position13>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1895" Column="39" TopLine="1869"/>
+        <Caret Line="1910" Column="43" TopLine="1890"/>
       </Position13>
       <Position14>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1905" Column="44" TopLine="1879"/>
+        <Caret Line="2814" Column="35" TopLine="2794"/>
       </Position14>
       <Position15>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2809" Column="36" TopLine="2783"/>
+        <Caret Line="2880" Column="37" TopLine="2860"/>
       </Position15>
       <Position16>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2875" Column="38" TopLine="2849"/>
+        <Caret Line="3153" Column="47" TopLine="3133"/>
       </Position16>
       <Position17>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3148" Column="48" TopLine="3122"/>
+        <Caret Line="3163" Column="47" TopLine="3143"/>
       </Position17>
       <Position18>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3158" Column="48" TopLine="3132"/>
+        <Caret Line="3295" Column="35" TopLine="3275"/>
       </Position18>
       <Position19>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3290" Column="36" TopLine="3263"/>
+        <Caret Line="3319" Column="46" TopLine="3299"/>
       </Position19>
       <Position20>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3314" Column="47" TopLine="3287"/>
+        <Caret Line="3322" Column="46" TopLine="3302"/>
       </Position20>
       <Position21>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3317" Column="47" TopLine="3290"/>
+        <Caret Line="3517" Column="5" TopLine="3500"/>
       </Position21>
       <Position22>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3489" Column="93" TopLine="3485"/>
+        <Caret Line="578" Column="37" TopLine="573"/>
       </Position22>
       <Position23>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1264" Column="59" TopLine="1248"/>
+        <Caret Line="580" Column="29" TopLine="568"/>
       </Position23>
       <Position24>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1268" Column="32" TopLine="1248"/>
+        <Caret Line="3505" Column="41" TopLine="3501"/>
       </Position24>
       <Position25>
         <Filename Value="unit2.pas"/>
-        <Caret Line="100" Column="83" TopLine="84"/>
+        <Caret Line="525" Column="30" TopLine="514"/>
       </Position25>
       <Position26>
-        <Filename Value="dbases_sqlite.pas"/>
-        <Caret Line="114" Column="3" TopLine="98"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="580" Column="37" TopLine="560"/>
       </Position26>
       <Position27>
-        <Filename Value="dbases_sqlite.pas"/>
-        <Caret Line="374" Column="70" TopLine="372"/>
+        <Filename Value="unit2.pas"/>
+        <Caret Line="3505" Column="36" TopLine="3490"/>
       </Position27>
       <Position28>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2613" TopLine="2597"/>
+        <Caret Line="525" Column="30" TopLine="514"/>
       </Position28>
       <Position29>
         <Filename Value="unit2.pas"/>
-        <Caret Line="4140" Column="128" TopLine="4114"/>
+        <Caret Line="582" Column="17" TopLine="570"/>
       </Position29>
       <Position30>
         <Filename Value="unit2.pas"/>
-        <Caret Line="369" Column="8" TopLine="354"/>
+        <Caret Line="580" Column="28" TopLine="570"/>
       </Position30>
     </JumpHistory>
   </ProjectOptions>
@@ -799,7 +572,6 @@
     </CodeGeneration>
     <Linking>
       <Debugging>
-        <GenerateDebugInfo Value="False"/>
         <DebugInfoType Value="dsDwarf2Set"/>
         <StripSymbols Value="True"/>
       </Debugging>

--- a/quickhash.lpi
+++ b/quickhash.lpi
@@ -92,8 +92,8 @@
         <ResourceBaseClass Value="Form"/>
         <UnitName Value="Unit2"/>
         <IsVisibleTab Value="True"/>
-        <TopLine Value="2239"/>
-        <CursorPos X="3" Y="2262"/>
+        <TopLine Value="3044"/>
+        <CursorPos X="4" Y="3076"/>
         <UsageCount Value="201"/>
         <Loaded Value="True"/>
         <LoadedDesigner Value="True"/>
@@ -431,123 +431,123 @@
     <JumpHistory Count="30" HistoryIndex="29">
       <Position1>
         <Filename Value="unit2.pas"/>
-        <Caret Line="582" Column="58" TopLine="563"/>
+        <Caret Line="1837" Column="38" TopLine="1818"/>
       </Position1>
       <Position2>
         <Filename Value="unit2.pas"/>
-        <Caret Line="957" Column="39" TopLine="937"/>
+        <Caret Line="1900" Column="38" TopLine="1880"/>
       </Position2>
       <Position3>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1085" Column="41" TopLine="1065"/>
+        <Caret Line="1910" Column="43" TopLine="1890"/>
       </Position3>
       <Position4>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1824" Column="32" TopLine="1804"/>
+        <Caret Line="2814" Column="35" TopLine="2794"/>
       </Position4>
       <Position5>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1837" Column="38" TopLine="1818"/>
+        <Caret Line="2880" Column="37" TopLine="2860"/>
       </Position5>
       <Position6>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1900" Column="38" TopLine="1880"/>
+        <Caret Line="3153" Column="47" TopLine="3133"/>
       </Position6>
       <Position7>
         <Filename Value="unit2.pas"/>
-        <Caret Line="1910" Column="43" TopLine="1890"/>
+        <Caret Line="3163" Column="47" TopLine="3143"/>
       </Position7>
       <Position8>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2814" Column="35" TopLine="2794"/>
+        <Caret Line="3295" Column="35" TopLine="3275"/>
       </Position8>
       <Position9>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2880" Column="37" TopLine="2860"/>
+        <Caret Line="3319" Column="46" TopLine="3299"/>
       </Position9>
       <Position10>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3153" Column="47" TopLine="3133"/>
+        <Caret Line="3322" Column="46" TopLine="3302"/>
       </Position10>
       <Position11>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3163" Column="47" TopLine="3143"/>
+        <Caret Line="3517" Column="5" TopLine="3500"/>
       </Position11>
       <Position12>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3295" Column="35" TopLine="3275"/>
+        <Caret Line="578" Column="37" TopLine="573"/>
       </Position12>
       <Position13>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3319" Column="46" TopLine="3299"/>
+        <Caret Line="580" Column="29" TopLine="568"/>
       </Position13>
       <Position14>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3322" Column="46" TopLine="3302"/>
+        <Caret Line="3505" Column="41" TopLine="3501"/>
       </Position14>
       <Position15>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3517" Column="5" TopLine="3500"/>
+        <Caret Line="525" Column="30" TopLine="514"/>
       </Position15>
       <Position16>
         <Filename Value="unit2.pas"/>
-        <Caret Line="578" Column="37" TopLine="573"/>
+        <Caret Line="580" Column="37" TopLine="560"/>
       </Position16>
       <Position17>
         <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="29" TopLine="568"/>
+        <Caret Line="3505" Column="36" TopLine="3490"/>
       </Position17>
       <Position18>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3505" Column="41" TopLine="3501"/>
+        <Caret Line="525" Column="30" TopLine="514"/>
       </Position18>
       <Position19>
         <Filename Value="unit2.pas"/>
-        <Caret Line="525" Column="30" TopLine="514"/>
+        <Caret Line="582" Column="17" TopLine="570"/>
       </Position19>
       <Position20>
         <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="37" TopLine="560"/>
+        <Caret Line="580" Column="28" TopLine="570"/>
       </Position20>
       <Position21>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3505" Column="36" TopLine="3490"/>
+        <Caret Line="3703" Column="7" TopLine="3701"/>
       </Position21>
       <Position22>
         <Filename Value="unit2.pas"/>
-        <Caret Line="525" Column="30" TopLine="514"/>
+        <Caret Line="2407" Column="3" TopLine="2405"/>
       </Position22>
       <Position23>
         <Filename Value="unit2.pas"/>
-        <Caret Line="582" Column="17" TopLine="570"/>
+        <Caret Line="2265" Column="35" TopLine="2262"/>
       </Position23>
       <Position24>
         <Filename Value="unit2.pas"/>
-        <Caret Line="580" Column="28" TopLine="570"/>
+        <Caret Line="2411" Column="79" TopLine="2406"/>
       </Position24>
       <Position25>
         <Filename Value="unit2.pas"/>
-        <Caret Line="3703" Column="7" TopLine="3701"/>
+        <Caret Line="2248" Column="29" TopLine="2241"/>
       </Position25>
       <Position26>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2407" Column="3" TopLine="2405"/>
+        <Caret Line="2411" Column="3" TopLine="2409"/>
       </Position26>
       <Position27>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2265" Column="35" TopLine="2262"/>
+        <Caret Line="2262" Column="3" TopLine="2239"/>
       </Position27>
       <Position28>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2411" Column="79" TopLine="2406"/>
+        <Caret Line="2422" Column="3" TopLine="2420"/>
       </Position28>
       <Position29>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2248" Column="29" TopLine="2241"/>
+        <Caret Line="2952" Column="3" TopLine="2947"/>
       </Position29>
       <Position30>
         <Filename Value="unit2.pas"/>
-        <Caret Line="2411" Column="3" TopLine="2409"/>
+        <Caret Line="2422" Column="12" TopLine="2420"/>
       </Position30>
     </JumpHistory>
   </ProjectOptions>

--- a/udisplaygrid.lfm
+++ b/udisplaygrid.lfm
@@ -1,11 +1,11 @@
 object frmDisplayGrid1: TfrmDisplayGrid1
-  Left = 691
-  Height = 687
-  Top = 161
-  Width = 903
+  Left = 313
+  Height = 527
+  Top = 216
+  Width = 790
   Caption = 'QuickHash - Copy Results'
-  ClientHeight = 687
-  ClientWidth = 903
+  ClientHeight = 527
+  ClientWidth = 790
   OnClose = FormClose
   OnCreate = FormCreate
   Position = poScreenCenter
@@ -14,7 +14,7 @@ object frmDisplayGrid1: TfrmDisplayGrid1
     Left = 280
     Height = 23
     Hint = 'Click to have the display grid content copied '#13#10'to clipboard. To have ENTIRE grid copied, '#13#10'ensure top left cell is selected using mouse. '#13#10'Otherwise it copies from active position in the grid. '
-    Top = 640
+    Top = 480
     Width = 80
     Anchors = [akLeft, akBottom]
     Caption = 'Clipboard'
@@ -24,9 +24,9 @@ object frmDisplayGrid1: TfrmDisplayGrid1
   end
   object RecursiveDisplayGrid_COPY: TDBGrid
     Left = 16
-    Height = 592
+    Height = 432
     Top = 24
-    Width = 864
+    Width = 751
     Anchors = [akTop, akLeft, akRight, akBottom]
     Color = clWindow
     Columns = <>
@@ -38,7 +38,7 @@ object frmDisplayGrid1: TfrmDisplayGrid1
   object CopyTabDBNavigator: TDBNavigator
     Left = 16
     Height = 25
-    Top = 640
+    Top = 480
     Width = 241
     Anchors = [akLeft, akBottom]
     BevelOuter = bvNone

--- a/unit2.lfm
+++ b/unit2.lfm
@@ -5,7 +5,7 @@ object MainForm: TMainForm
   Width = 1023
   AllowDropFiles = True
   Caption = 'QuickHash v3.0.1 (Jan 2018) - The easy and convenient way to hash data in Linux, OSX and Windows'
-  ClientHeight = 711
+  ClientHeight = 730
   ClientWidth = 1023
   Menu = MainMenu1
   OnClose = FormClose
@@ -16,31 +16,31 @@ object MainForm: TMainForm
   LCLVersion = '1.6.4.0'
   object PageControl1: TPageControl
     Left = 16
-    Height = 673
+    Height = 692
     Top = 24
     Width = 991
-    ActivePage = TabSheet1
+    ActivePage = TabSheet3
     Anchors = [akTop, akLeft, akRight, akBottom]
     ParentShowHint = False
     ShowHint = True
-    TabIndex = 0
+    TabIndex = 2
     TabOrder = 0
     object TabSheet1: TTabSheet
       Hint = 'Hash portions of text'
       Caption = 'Te&xt'
-      ClientHeight = 647
-      ClientWidth = 983
+      ClientHeight = 653
+      ClientWidth = 985
       OnContextPopup = TabSheet1ContextPopup
       ParentShowHint = False
       object TextHashingGroupBox: TGroupBox
         Left = 120
         Height = 534
         Top = 10
-        Width = 847
+        Width = 849
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Text Hashing'
-        ClientHeight = 513
-        ClientWidth = 843
+        ClientHeight = 511
+        ClientWidth = 841
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -51,10 +51,11 @@ object MainForm: TMainForm
           Height = 183
           Hint = 'Type or paste and watch hash value change.'#13#10'For amounts larger than several hundred Kb, save'#13#10'data to a file and use File Hashing instead. '
           Top = 9
-          Width = 821
+          Width = 819
           Anchors = [akTop, akLeft, akRight]
           Lines.Strings = (
             'Type or paste text here - hash will update as you type'
+            ''
             ''
             ''
             ''
@@ -76,12 +77,13 @@ object MainForm: TMainForm
           Height = 56
           Hint = 'This is the hash of ALL THE TEXT in the textarea above'#13#10'For line-by-line analysis, use the button'#13#10#13#10'The hash value can be copied from here'#13#10'to clipboard (highlight and press Ctrl + C or right click ''Copy'''
           Top = 408
-          Width = 821
+          Width = 819
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           Font.Height = -13
           Lines.Strings = (
             '...hash value'
+            ''
             ''
             ''
             ''
@@ -99,10 +101,10 @@ object MainForm: TMainForm
         end
         object lbleExpectedHashText: TLabeledEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated hash matches the computed hash.'#13#10'To resume normal behaviour, return value '#13#10'to ''...'' (3 dots only)'#13#10'It expects you to paste hash values '#13#10'of the correct length'
           Top = 368
-          Width = 822
+          Width = 820
           Anchors = [akTop, akLeft, akRight]
           EditLabel.AnchorSideLeft.Control = lbleExpectedHashText
           EditLabel.AnchorSideRight.Control = lbleExpectedHashText
@@ -111,7 +113,7 @@ object MainForm: TMainForm
           EditLabel.Left = 8
           EditLabel.Height = 16
           EditLabel.Top = 349
-          EditLabel.Width = 822
+          EditLabel.Width = 820
           EditLabel.Caption = 'Expected Hash Value (clear, then paste value from other utility)'
           EditLabel.ParentColor = False
           ParentShowHint = False
@@ -126,8 +128,8 @@ object MainForm: TMainForm
           Top = 208
           Width = 448
           Caption = 'Line-By-Line Hashing Options'
-          ClientHeight = 99
-          ClientWidth = 444
+          ClientHeight = 97
+          ClientWidth = 440
           TabOrder = 3
           object btnFLBL: TButton
             Left = 8
@@ -155,10 +157,10 @@ object MainForm: TMainForm
           end
           object cbToggleInputDataToOutputFile: TCheckBox
             Left = 184
-            Height = 20
+            Height = 18
             Hint = 'If unticked, source text (including '#13#10'hashes) will be output. '#13#10'If ticked, only the computed'#13#10'hashes will be output.'
             Top = 16
-            Width = 192
+            Width = 213
             Caption = 'Source text INcluded in output'
             OnChange = cbToggleInputDataToOutputFileChange
             ParentShowHint = False
@@ -168,9 +170,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseTEXT: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Top = 472
-          Width = 88
+          Width = 93
           Caption = 'Switch case'
           OnChange = cbFlipCaseTEXTChange
           TabOrder = 4
@@ -228,8 +230,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -252,8 +254,8 @@ object MainForm: TMainForm
         Top = 152
         Width = 96
         Caption = 'System RAM'
-        ClientHeight = 60
-        ClientWidth = 92
+        ClientHeight = 58
+        ClientWidth = 88
         Font.Height = -13
         ParentFont = False
         TabOrder = 2
@@ -280,8 +282,8 @@ object MainForm: TMainForm
         Width = 850
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Single File Hashing'
-        ClientHeight = 377
-        ClientWidth = 846
+        ClientHeight = 375
+        ClientWidth = 842
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -364,6 +366,7 @@ object MainForm: TMainForm
           Color = clSilver
           Lines.Strings = (
             'Computed hash will appear here...'
+            ''
             ''
             ''
             ''
@@ -497,8 +500,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -517,19 +520,19 @@ object MainForm: TMainForm
     object TabSheet3: TTabSheet
       Hint = 'Compute hashes for multiple files in a directory'#13#10'recursively, or just those in the root of the directory'
       Caption = 'FileS'
-      ClientHeight = 647
-      ClientWidth = 983
+      ClientHeight = 653
+      ClientWidth = 985
       ParentShowHint = False
       ShowHint = True
       object DirectoryHashingGroupBox: TGroupBox
         Left = 120
-        Height = 621
+        Height = 627
         Top = 10
-        Width = 853
+        Width = 855
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Hash all files in chosen directory - recursive by default'
-        ClientHeight = 600
-        ClientWidth = 849
+        ClientHeight = 604
+        ClientWidth = 847
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -549,10 +552,10 @@ object MainForm: TMainForm
         end
         object btnRecursiveDirectoryHashing: TButton
           Left = 8
-          Height = 23
+          Height = 20
           Hint = 'All files and subdirectories below the chosen '#10'directory will be hashed, subject to selected'#10'options. Recursive by default.'
           Top = 96
-          Width = 99
+          Width = 109
           AutoSize = True
           Caption = 'Select &Folder'
           Color = 8454016
@@ -565,10 +568,10 @@ object MainForm: TMainForm
         end
         object DirSelectedField: TEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'The chosen parent directory'
           Top = 136
-          Width = 822
+          Width = 820
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           TabOrder = 0
@@ -588,17 +591,17 @@ object MainForm: TMainForm
           Left = 520
           Height = 16
           Top = 56
-          Width = 233
+          Width = 231
           Anchors = [akTop, akLeft, akRight]
           Caption = '% Complete:'
           ParentColor = False
         end
         object btnClipboardResults: TButton
           Left = 224
-          Height = 26
+          Height = 20
           Hint = 'Press this to copy entire grid content to RAM'
           Top = 96
-          Width = 80
+          Width = 90
           AutoSize = True
           Caption = 'Clipboard'
           Enabled = False
@@ -609,10 +612,10 @@ object MainForm: TMainForm
         end
         object btnStopScan1: TButton
           Left = 152
-          Height = 23
+          Height = 20
           Hint = 'Click to abort the hash as soon as the'#10'current file hashing action completes. '
           Top = 96
-          Width = 48
+          Width = 70
           AutoSize = True
           Caption = 'S&top'
           OnClick = btnStopScan1Click
@@ -621,18 +624,18 @@ object MainForm: TMainForm
         end
         object chkRecursiveDirOverride: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Hash files just in the root of the chosen folder'#13#10'Sub-folders will be ignored. '
           Top = 8
-          Width = 162
+          Width = 181
           Caption = 'Ignoring sub-directories?'
           TabOrder = 1
         end
         object Label5: TLabel
           Left = 110
-          Height = 24
+          Height = 23
           Top = 312
-          Width = 606
+          Width = 653
           Caption = 'This area will be populated once the scan is complete...please wait!'
           Font.Height = -20
           ParentColor = False
@@ -645,8 +648,8 @@ object MainForm: TMainForm
           AnchorSideRight.Side = asrBottom
           Left = 8
           Height = 23
-          Top = 568
-          Width = 841
+          Top = 572
+          Width = 839
           Align = alCustom
           Anchors = [akLeft, akRight]
           AutoSize = False
@@ -669,7 +672,7 @@ object MainForm: TMainForm
           Left = 686
           Height = 16
           Top = 56
-          Width = 163
+          Width = 161
           Anchors = [akTop, akLeft, akRight]
           Caption = '...'
           ParentColor = False
@@ -716,16 +719,16 @@ object MainForm: TMainForm
         end
         object chkHiddenFiles: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Tick to have files in hidden folders hashed. '#13#10'Hidden files are hashed by default anyway '#13#10'but hidden folders, ergo their contents, are not found by default.'
           Top = 64
-          Width = 130
+          Width = 144
           Caption = 'Hidden folders too?'
           TabOrder = 6
         end
         object FileMaskField2: TEdit
           Left = 288
-          Height = 24
+          Height = 22
           Hint = 'Use an asterix, full stop and the file type '#10'extension, seperated by a semi-colon.'#10'NO space characters'
           Top = 36
           Width = 200
@@ -737,19 +740,19 @@ object MainForm: TMainForm
         end
         object FileTypeMaskCheckBox2: TCheckBox
           Left = 288
-          Height = 20
+          Height = 18
           Hint = 'Select file type masks (e.g. *.doc;*.pdf)'#13#10'Remember that JPG and jpg are different'#13#10'file names on Linux and OSX!!'
           Top = 8
-          Width = 123
+          Width = 134
           Caption = 'Choose file types?'
           OnChange = FileTypeMaskCheckBox2Change
           TabOrder = 8
         end
         object ZVDateTimePickerFileSTab: TZVDateTimePicker
           Left = 128
-          Height = 24
+          Height = 20
           Top = 36
-          Width = 138
+          Width = 151
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -771,19 +774,19 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileSTab: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the directory to hash.'
           Top = 36
-          Width = 108
+          Width = 113
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileSTabChange
           TabOrder = 10
         end
         object RecursiveDisplayGrid1: TDBGrid
           Left = 8
-          Height = 376
+          Height = 380
           Top = 176
-          Width = 843
+          Width = 841
           Anchors = [akTop, akLeft, akRight, akBottom]
           Color = clWindow
           Columns = <>
@@ -815,9 +818,9 @@ object MainForm: TMainForm
         end
         object cbLoadHashList: TCheckBox
           Left = 288
-          Height = 20
+          Height = 18
           Top = 64
-          Width = 98
+          Width = 108
           Caption = 'Load HashList'
           OnChange = cbLoadHashListChange
           TabOrder = 13
@@ -849,8 +852,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -886,8 +889,8 @@ object MainForm: TMainForm
         Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Hash files in chosen directory, copy them, and re-hash the copied files (recursive by default) '
-        ClientHeight = 575
-        ClientWidth = 841
+        ClientHeight = 573
+        ClientWidth = 837
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -1259,8 +1262,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1294,8 +1297,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1318,8 +1321,8 @@ object MainForm: TMainForm
         Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Choose two files and click ''Compare Files'''
-        ClientHeight = 275
-        ClientWidth = 841
+        ClientHeight = 273
+        ClientWidth = 837
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1492,8 +1495,8 @@ object MainForm: TMainForm
         Width = 839
         Anchors = [akLeft, akRight, akBottom]
         Caption = 'Summary'
-        ClientHeight = 156
-        ClientWidth = 835
+        ClientHeight = 154
+        ClientWidth = 831
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1521,8 +1524,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1543,8 +1546,8 @@ object MainForm: TMainForm
         Width = 839
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Compare two folders'
-        ClientHeight = 386
-        ClientWidth = 835
+        ClientHeight = 384
+        ClientWidth = 831
         DragMode = dmAutomatic
         Font.Height = -13
         ParentFont = False
@@ -1848,8 +1851,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1870,8 +1873,8 @@ object MainForm: TMainForm
         Width = 847
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Base64 Decoder and Hasher'
-        ClientHeight = 553
-        ClientWidth = 843
+        ClientHeight = 551
+        ClientWidth = 839
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -2020,10 +2023,10 @@ object MainForm: TMainForm
     AnchorSideRight.Side = asrBottom
     Cursor = crHandPoint
     Left = 736
-    Height = 13
+    Height = 16
     Hint = 'Click to open URL in browser'
     Top = 1
-    Width = 170
+    Width = 207
     BorderSpacing.Right = 10
     Caption = 'http://www.quickhash-gui.org'
     Font.Color = clBlue

--- a/unit2.lfm
+++ b/unit2.lfm
@@ -1,11 +1,11 @@
 object MainForm: TMainForm
-  Left = 291
-  Height = 656
-  Top = 234
+  Left = 284
+  Height = 720
+  Top = 161
   Width = 1025
   AllowDropFiles = True
   Caption = 'QuickHash v3.0.0 (Jan 2018) - The easy and convenient way to hash data in Linux, OSX and Windows'
-  ClientHeight = 637
+  ClientHeight = 720
   ClientWidth = 1025
   Menu = MainMenu1
   OnClose = FormClose
@@ -16,31 +16,31 @@ object MainForm: TMainForm
   LCLVersion = '1.6.4.0'
   object PageControl1: TPageControl
     Left = 16
-    Height = 599
+    Height = 682
     Top = 24
     Width = 993
-    ActivePage = TabSheet1
+    ActivePage = TabSheet2
     Anchors = [akTop, akLeft, akRight, akBottom]
     ParentShowHint = False
     ShowHint = True
-    TabIndex = 0
+    TabIndex = 1
     TabOrder = 0
     object TabSheet1: TTabSheet
       Hint = 'Hash portions of text'
       Caption = 'Te&xt'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 643
+      ClientWidth = 987
       OnContextPopup = TabSheet1ContextPopup
       ParentShowHint = False
       object TextHashingGroupBox: TGroupBox
         Left = 120
         Height = 534
         Top = 10
-        Width = 849
+        Width = 851
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Text Hashing'
-        ClientHeight = 513
-        ClientWidth = 845
+        ClientHeight = 511
+        ClientWidth = 843
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -51,10 +51,13 @@ object MainForm: TMainForm
           Height = 183
           Hint = 'Type or paste and watch hash value change.'#13#10'For amounts larger than several hundred Kb, save'#13#10'data to a file and use File Hashing instead. '
           Top = 9
-          Width = 823
+          Width = 821
           Anchors = [akTop, akLeft, akRight]
           Lines.Strings = (
             'Type or paste text here - hash will update as you type'
+            ''
+            ''
+            ''
             ''
             ''
             ''
@@ -73,12 +76,15 @@ object MainForm: TMainForm
           Height = 56
           Hint = 'This is the hash of ALL THE TEXT in the textarea above'#13#10'For line-by-line analysis, use the button'#13#10#13#10'The hash value can be copied from here'#13#10'to clipboard (highlight and press Ctrl + C or right click ''Copy'''
           Top = 408
-          Width = 823
+          Width = 821
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           Font.Height = -13
           Lines.Strings = (
             '...hash value'
+            ''
+            ''
+            ''
             ''
             ''
             ''
@@ -93,10 +99,10 @@ object MainForm: TMainForm
         end
         object lbleExpectedHashText: TLabeledEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated hash matches the computed hash.'#13#10'To resume normal behaviour, return value '#13#10'to ''...'' (3 dots only)'#13#10'It expects you to paste hash values '#13#10'of the correct length'
           Top = 368
-          Width = 824
+          Width = 822
           Anchors = [akTop, akLeft, akRight]
           EditLabel.AnchorSideLeft.Control = lbleExpectedHashText
           EditLabel.AnchorSideRight.Control = lbleExpectedHashText
@@ -105,7 +111,7 @@ object MainForm: TMainForm
           EditLabel.Left = 8
           EditLabel.Height = 16
           EditLabel.Top = 349
-          EditLabel.Width = 824
+          EditLabel.Width = 822
           EditLabel.Caption = 'Expected Hash Value (clear, then paste value from other utility)'
           EditLabel.ParentColor = False
           ParentShowHint = False
@@ -120,8 +126,8 @@ object MainForm: TMainForm
           Top = 208
           Width = 448
           Caption = 'Line-By-Line Hashing Options'
-          ClientHeight = 99
-          ClientWidth = 444
+          ClientHeight = 97
+          ClientWidth = 440
           TabOrder = 3
           object btnFLBL: TButton
             Left = 8
@@ -149,10 +155,10 @@ object MainForm: TMainForm
           end
           object cbToggleInputDataToOutputFile: TCheckBox
             Left = 184
-            Height = 20
+            Height = 18
             Hint = 'If unticked, source text (including '#13#10'hashes) will be output. '#13#10'If ticked, only the computed'#13#10'hashes will be output.'
             Top = 16
-            Width = 192
+            Width = 213
             Caption = 'Source text INcluded in output'
             OnChange = cbToggleInputDataToOutputFileChange
             ParentShowHint = False
@@ -162,9 +168,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseTEXT: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Top = 472
-          Width = 88
+          Width = 93
           Caption = 'Switch case'
           OnChange = cbFlipCaseTEXTChange
           TabOrder = 4
@@ -222,8 +228,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -246,8 +252,8 @@ object MainForm: TMainForm
         Top = 152
         Width = 96
         Caption = 'System RAM'
-        ClientHeight = 60
-        ClientWidth = 92
+        ClientHeight = 58
+        ClientWidth = 88
         Font.Height = -13
         ParentFont = False
         TabOrder = 2
@@ -264,18 +270,18 @@ object MainForm: TMainForm
     object TabSheet2: TTabSheet
       Hint = 'Hash a single file (useful for hashing disks in Linux)'
       Caption = 'F&ile'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 643
+      ClientWidth = 987
       ParentShowHint = False
       object FileHashingGroupBox: TGroupBox
         Left = 120
         Height = 398
         Top = 10
-        Width = 850
+        Width = 852
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Single File Hashing'
-        ClientHeight = 377
-        ClientWidth = 846
+        ClientHeight = 375
+        ClientWidth = 844
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -286,7 +292,7 @@ object MainForm: TMainForm
           Left = 552
           Height = 32
           Top = 47
-          Width = 264
+          Width = 294
           Caption = 'As root, this section can be used to hash disks'#10'e.g. /dev/sdX or /dev/sdaX, or /dev/hdX'
           ParentColor = False
           WordWrap = True
@@ -309,9 +315,9 @@ object MainForm: TMainForm
         end
         object edtFileNameToBeHashed: TEdit
           Left = 6
-          Height = 24
+          Height = 22
           Top = 96
-          Width = 826
+          Width = 824
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           ReadOnly = True
@@ -320,10 +326,10 @@ object MainForm: TMainForm
         end
         object btnHashFile: TButton
           Left = 6
-          Height = 23
+          Height = 20
           Hint = 'Choose a single file to hash (or Linux physical device e.g. /dev/sda)'
           Top = 64
-          Width = 83
+          Width = 87
           AutoSize = True
           Caption = 'Select &File'
           Color = 8454016
@@ -336,16 +342,16 @@ object MainForm: TMainForm
         end
         object StatusBar1: TStatusBar
           Left = 0
-          Height = 20
-          Top = 357
-          Width = 846
+          Height = 15
+          Top = 360
+          Width = 844
           Panels = <>
         end
         object lblDragAndDropNudge: TLabel
           Left = 112
           Height = 16
           Top = 64
-          Width = 115
+          Width = 127
           Caption = 'or drag n drop a file'
           ParentColor = False
         end
@@ -353,11 +359,14 @@ object MainForm: TMainForm
           Left = 6
           Height = 58
           Top = 136
-          Width = 826
+          Width = 824
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           Lines.Strings = (
             'Computed hash will appear here...'
+            ''
+            ''
+            ''
             ''
             ''
             ''
@@ -368,10 +377,10 @@ object MainForm: TMainForm
         end
         object lbleExpectedHash: TLabeledEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated file hash matches it, or not. '
           Top = 264
-          Width = 824
+          Width = 822
           Anchors = [akTop, akLeft, akRight]
           EditLabel.AnchorSideLeft.Control = lbleExpectedHash
           EditLabel.AnchorSideRight.Control = lbleExpectedHash
@@ -380,7 +389,7 @@ object MainForm: TMainForm
           EditLabel.Left = 8
           EditLabel.Height = 16
           EditLabel.Top = 245
-          EditLabel.Width = 824
+          EditLabel.Width = 822
           EditLabel.Caption = 'Expected Hash Value (paste from other utility before or after file hashing)'
           EditLabel.ParentColor = False
           MaxLength = 128
@@ -398,10 +407,10 @@ object MainForm: TMainForm
         end
         object ZVDateTimePickerFileTab: TZVDateTimePicker
           Left = 8
-          Height = 24
+          Height = 20
           Hint = 'Enter date and time (hours and minutes) '#13#10'to start the process. Must be in the future!'
           Top = 32
-          Width = 138
+          Width = 151
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -425,10 +434,10 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileTab: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the file to hash.'
           Top = 8
-          Width = 108
+          Width = 113
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileTabChange
           ParentShowHint = False
@@ -465,9 +474,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseFILE: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Top = 208
-          Width = 88
+          Width = 93
           Caption = 'Switch case'
           OnChange = cbFlipCaseFILEChange
           TabOrder = 9
@@ -488,8 +497,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -508,19 +517,19 @@ object MainForm: TMainForm
     object TabSheet3: TTabSheet
       Hint = 'Compute hashes for multiple files in a directory'#13#10'recursively, or just those in the root of the directory'
       Caption = 'FileS'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 643
+      ClientWidth = 987
       ParentShowHint = False
       ShowHint = True
       object DirectoryHashingGroupBox: TGroupBox
         Left = 120
-        Height = 547
+        Height = 617
         Top = 10
-        Width = 855
+        Width = 857
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Hash all files in chosen directory - recursive by default'
-        ClientHeight = 526
-        ClientWidth = 851
+        ClientHeight = 594
+        ClientWidth = 849
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -540,10 +549,10 @@ object MainForm: TMainForm
         end
         object btnRecursiveDirectoryHashing: TButton
           Left = 8
-          Height = 23
+          Height = 20
           Hint = 'All files and subdirectories below the chosen '#10'directory will be hashed, subject to selected'#10'options. Recursive by default.'
           Top = 96
-          Width = 99
+          Width = 109
           AutoSize = True
           Caption = 'Select &Folder'
           Color = 8454016
@@ -556,10 +565,10 @@ object MainForm: TMainForm
         end
         object DirSelectedField: TEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'The chosen parent directory'
           Top = 136
-          Width = 824
+          Width = 822
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           TabOrder = 0
@@ -579,17 +588,17 @@ object MainForm: TMainForm
           Left = 520
           Height = 16
           Top = 56
-          Width = 97
+          Width = 95
           Anchors = [akTop, akLeft, akRight]
           Caption = '% Complete:'
           ParentColor = False
         end
         object btnClipboardResults: TButton
           Left = 224
-          Height = 26
+          Height = 20
           Hint = 'Press this to copy entire grid content to RAM'
           Top = 96
-          Width = 80
+          Width = 90
           AutoSize = True
           Caption = 'Clipboard'
           Enabled = False
@@ -600,10 +609,10 @@ object MainForm: TMainForm
         end
         object btnStopScan1: TButton
           Left = 152
-          Height = 23
+          Height = 20
           Hint = 'Click to abort the hash as soon as the'#10'current file hashing action completes. '
           Top = 96
-          Width = 48
+          Width = 70
           AutoSize = True
           Caption = 'S&top'
           OnClick = btnStopScan1Click
@@ -612,18 +621,18 @@ object MainForm: TMainForm
         end
         object chkRecursiveDirOverride: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Hash files just in the root of the chosen folder'#13#10'Sub-folders will be ignored. '
           Top = 8
-          Width = 162
+          Width = 181
           Caption = 'Ignoring sub-directories?'
           TabOrder = 1
         end
         object Label5: TLabel
           Left = 110
-          Height = 24
+          Height = 23
           Top = 312
-          Width = 606
+          Width = 653
           Caption = 'This area will be populated once the scan is complete...please wait!'
           Font.Height = -20
           ParentColor = False
@@ -636,8 +645,8 @@ object MainForm: TMainForm
           AnchorSideRight.Side = asrBottom
           Left = 8
           Height = 23
-          Top = 496
-          Width = 843
+          Top = 562
+          Width = 841
           Align = alCustom
           Anchors = [akLeft, akRight]
           AutoSize = False
@@ -660,7 +669,7 @@ object MainForm: TMainForm
           Left = 686
           Height = 16
           Top = 56
-          Width = 165
+          Width = 163
           Anchors = [akTop, akLeft, akRight]
           Caption = '...'
           ParentColor = False
@@ -707,16 +716,16 @@ object MainForm: TMainForm
         end
         object chkHiddenFiles: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Tick to have files in hidden folders hashed. '#13#10'Hidden files are hashed by default anyway '#13#10'but hidden folders, ergo their contents, are not found by default.'
           Top = 64
-          Width = 130
+          Width = 144
           Caption = 'Hidden folders too?'
           TabOrder = 6
         end
         object FileMaskField2: TEdit
           Left = 288
-          Height = 24
+          Height = 22
           Hint = 'Use an asterix, full stop and the file type '#10'extension, seperated by a semi-colon.'#10'NO space characters'
           Top = 36
           Width = 200
@@ -728,19 +737,19 @@ object MainForm: TMainForm
         end
         object FileTypeMaskCheckBox2: TCheckBox
           Left = 288
-          Height = 20
+          Height = 18
           Hint = 'Select file type masks (e.g. *.doc;*.pdf)'#13#10'Remember that JPG and jpg are different'#13#10'file names on Linux and OSX!!'
           Top = 8
-          Width = 123
+          Width = 134
           Caption = 'Choose file types?'
           OnChange = FileTypeMaskCheckBox2Change
           TabOrder = 8
         end
         object ZVDateTimePickerFileSTab: TZVDateTimePicker
           Left = 128
-          Height = 24
+          Height = 20
           Top = 36
-          Width = 138
+          Width = 151
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -762,19 +771,19 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileSTab: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the directory to hash.'
           Top = 36
-          Width = 108
+          Width = 113
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileSTabChange
           TabOrder = 10
         end
         object RecursiveDisplayGrid1: TDBGrid
           Left = 8
-          Height = 302
+          Height = 370
           Top = 176
-          Width = 845
+          Width = 843
           Anchors = [akTop, akLeft, akRight, akBottom]
           Color = clWindow
           Columns = <>
@@ -806,9 +815,9 @@ object MainForm: TMainForm
         end
         object cbLoadHashList: TCheckBox
           Left = 288
-          Height = 20
+          Height = 18
           Top = 64
-          Width = 98
+          Width = 108
           Caption = 'Load HashList'
           OnChange = cbLoadHashListChange
           TabOrder = 13
@@ -840,8 +849,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -866,19 +875,19 @@ object MainForm: TMainForm
     object TabSheet4: TTabSheet
       Hint = 'Choose a directory, have its content hashed, files are copied to destination, and re-hashed.'
       Caption = '&Copy'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 643
+      ClientWidth = 987
       ParentShowHint = False
       ShowHint = True
       object CopyFilesHashingGroupBox: TGroupBox
         Left = 120
         Height = 596
         Top = 8
-        Width = 843
+        Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Hash files in chosen directory, copy them, and re-hash the copied files (recursive by default) '
-        ClientHeight = 575
-        ClientWidth = 839
+        ClientHeight = 573
+        ClientWidth = 837
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -888,18 +897,18 @@ object MainForm: TMainForm
           Left = 8
           Height = 184
           Top = 8
-          Width = 828
+          Width = 826
           Anchors = [akTop, akLeft, akRight]
           ClientHeight = 184
-          ClientWidth = 828
+          ClientWidth = 826
           TabOrder = 3
           OnClick = Panel1CopyAndHashOptionsClick
           object CheckBoxListOfDirsOnly: TCheckBox
             Left = 14
-            Height = 20
+            Height = 18
             Hint = 'Tick to have child directories listed, but no files inside hashed'
-            Top = 0
-            Width = 161
+            Top = 1
+            Width = 176
             Anchors = [akLeft]
             Caption = 'Just LIST sub-directories'
             OnChange = CheckBoxListOfDirsOnlyChange
@@ -907,20 +916,20 @@ object MainForm: TMainForm
           end
           object CheckBoxListOfDirsAndFilesOnly: TCheckBox
             Left = 14
-            Height = 20
+            Height = 18
             Hint = 'Tick to have child directories and files listed, but no files actually hashed'
             Top = 32
-            Width = 213
+            Width = 233
             Caption = 'Just LIST sub-directories and files'
             OnChange = CheckBoxListOfDirsAndFilesOnlyChange
             TabOrder = 1
           end
           object SaveToCSVCheckBox2: TCheckBox
             Left = 256
-            Height = 20
+            Height = 18
             Hint = 'Save results as CSV data (spreadsheet format)'
             Top = 0
-            Width = 134
+            Width = 138
             Caption = 'Save results (CSV)?'
             Checked = True
             State = cbChecked
@@ -928,17 +937,17 @@ object MainForm: TMainForm
           end
           object FileTypeMaskCheckBox1: TCheckBox
             Left = 448
-            Height = 20
+            Height = 18
             Hint = 'Only copy files of a particular type'
             Top = 32
-            Width = 123
+            Width = 134
             Caption = 'Choose file types?'
             OnChange = FileTypeMaskCheckBox1Change
             TabOrder = 4
           end
           object FileMaskField: TEdit
             Left = 464
-            Height = 24
+            Height = 22
             Hint = 'Use an asterix, full stop and the file type '#10'extension, seperated by a semi-colon.'#10'NO space characters'
             Top = 64
             Width = 248
@@ -950,10 +959,10 @@ object MainForm: TMainForm
           end
           object chkNoRecursiveCopy: TCheckBox
             Left = 448
-            Height = 20
+            Height = 18
             Hint = 'Only copy files found in the root of chosen directory'
-            Top = 0
-            Width = 152
+            Top = 1
+            Width = 168
             Anchors = [akLeft]
             Caption = 'Ignore sub-directories?'
             TabOrder = 3
@@ -962,7 +971,7 @@ object MainForm: TMainForm
             Left = 14
             Height = 16
             Top = 72
-            Width = 78
+            Width = 84
             Caption = '# Files in Dir:'
             ParentColor = False
           end
@@ -970,7 +979,7 @@ object MainForm: TMainForm
             Left = 14
             Height = 16
             Top = 104
-            Width = 103
+            Width = 110
             Caption = '# Files Examined:'
             ParentColor = False
           end
@@ -978,7 +987,7 @@ object MainForm: TMainForm
             Left = 14
             Height = 16
             Top = 136
-            Width = 75
+            Width = 77
             Caption = '% Complete:'
             ParentColor = False
           end
@@ -986,7 +995,7 @@ object MainForm: TMainForm
             Left = 464
             Height = 16
             Top = 97
-            Width = 70
+            Width = 73
             Caption = 'Start Time: '
             ParentColor = False
           end
@@ -994,7 +1003,7 @@ object MainForm: TMainForm
             Left = 464
             Height = 16
             Top = 121
-            Width = 67
+            Width = 71
             Caption = 'End Time:  '
             ParentColor = False
           end
@@ -1018,7 +1027,7 @@ object MainForm: TMainForm
             Left = 464
             Height = 16
             Top = 145
-            Width = 73
+            Width = 78
             Caption = 'Time Taken:'
             ParentColor = False
           end
@@ -1052,7 +1061,7 @@ object MainForm: TMainForm
             AnchorSideTop.Control = pbCopy
             AnchorSideTop.Side = asrBottom
             AnchorSideRight.Control = pbCopy
-            Left = 379
+            Left = 378
             Height = 16
             Top = 139
             Width = 12
@@ -1062,20 +1071,20 @@ object MainForm: TMainForm
           end
           object chkNoPathReconstruction: TCheckBox
             Left = 624
-            Height = 20
+            Height = 18
             Hint = 'Files will be copied to the root of your chosen '#10'destination directory. Duplicate file NAMES '#10'will have their names appended with '#10'DuplicatedNameX to avoid filesystem conflicts'
-            Top = 0
-            Width = 127
+            Top = 1
+            Width = 141
             Anchors = [akLeft]
             Caption = 'Don''t rebuild path?'
             TabOrder = 6
           end
           object chkCopyHidden: TCheckBox
             Left = 624
-            Height = 20
+            Height = 18
             Hint = 'If checked, will find hidden directories and files and copy those too'
             Top = 32
-            Width = 123
+            Width = 136
             Caption = 'Copy hidden files?'
             TabOrder = 7
           end
@@ -1089,20 +1098,20 @@ object MainForm: TMainForm
           end
           object lblschedulertickboxCopyTab: TCheckBox
             Left = 256
-            Height = 20
+            Height = 18
             Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the source and destination folders.'#13#10'Hash, copy and hash will start at the specified time'
             Top = 32
-            Width = 108
+            Width = 113
             Caption = 'Start at a time:'
             OnChange = lblschedulertickboxCopyTabChange
             TabOrder = 9
           end
           object ZVDateTimePickerCopyTab: TZVDateTimePicker
             Left = 272
-            Height = 24
+            Height = 20
             Hint = 'Enter date and time (hours and minutes) '
             Top = 64
-            Width = 138
+            Width = 151
             CenturyFrom = 1941
             MaxDate = 73050
             MinDate = 42736
@@ -1149,7 +1158,7 @@ object MainForm: TMainForm
         end
         object Edit2SourcePath: TEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'Show currently selected source directory'#13#10'Switch to UNC path by ticking "UNC Mode?"'
           Top = 216
           Width = 365
@@ -1162,7 +1171,7 @@ object MainForm: TMainForm
         end
         object Edit3DestinationPath: TEdit
           Left = 480
-          Height = 24
+          Height = 22
           Hint = 'Show currently selected destination directory'#13#10'Switch to UNC path by ticking "UNC Mode?"'
           Top = 216
           Width = 357
@@ -1175,9 +1184,9 @@ object MainForm: TMainForm
         end
         object StatusBar3: TStatusBar
           Left = 0
-          Height = 20
-          Top = 555
-          Width = 839
+          Height = 15
+          Top = 558
+          Width = 837
           Panels = <>
           ParentShowHint = False
         end
@@ -1185,7 +1194,7 @@ object MainForm: TMainForm
           Left = 8
           Height = 272
           Hint = 'Single click where to copy files FROM'
-          Top = 264
+          Top = 262
           Width = 365
           Anchors = [akLeft, akBottom]
           AutoExpand = True
@@ -1203,7 +1212,7 @@ object MainForm: TMainForm
           Left = 480
           Height = 272
           Hint = 'Single click where to copy files TO'
-          Top = 264
+          Top = 262
           Width = 357
           Anchors = [akLeft, akBottom]
           AutoExpand = True
@@ -1226,10 +1235,10 @@ object MainForm: TMainForm
         end
         object chkUNCMode: TCheckBox
           Left = 384
-          Height = 20
+          Height = 18
           Hint = 'Tick to enter UNC network path '#13#10'instead of using treeview selection'
           Top = 216
-          Width = 85
+          Width = 92
           Caption = 'UNC Mode?'
           OnChange = chkUNCModeChange
           TabOrder = 8
@@ -1250,8 +1259,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1268,8 +1277,8 @@ object MainForm: TMainForm
     end
     object TabSheet7: TTabSheet
       Caption = 'Compare Two Files'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 643
+      ClientWidth = 987
       object AlgorithmChoiceRadioBox5: TRadioGroup
         Left = 16
         Height = 129
@@ -1285,8 +1294,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1306,11 +1315,11 @@ object MainForm: TMainForm
         Left = 120
         Height = 296
         Top = 10
-        Width = 843
+        Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Choose two files and click ''Compare Files'''
-        ClientHeight = 275
-        ClientWidth = 839
+        ClientHeight = 273
+        ClientWidth = 837
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1346,7 +1355,7 @@ object MainForm: TMainForm
           Left = 130
           Height = 16
           Top = 176
-          Width = 40
+          Width = 43
           Caption = 'Result:'
           ParentColor = False
         end
@@ -1378,9 +1387,9 @@ object MainForm: TMainForm
         end
         object lblHashMatchResult: TLabel
           Left = 180
-          Height = 13
+          Height = 16
           Top = 176
-          Width = 9
+          Width = 10
           Caption = '...'
           Font.Style = [fsBold]
           ParentColor = False
@@ -1400,17 +1409,17 @@ object MainForm: TMainForm
           AnchorSideLeft.Control = GroupBox4
           AnchorSideRight.Control = GroupBox4
           Left = 0
-          Height = 20
-          Top = 255
-          Width = 839
+          Height = 15
+          Top = 258
+          Width = 837
           Panels = <>
         end
         object edtFileAName: TEdit
           Left = 128
-          Height = 24
+          Height = 22
           Hint = 'Path to the file you wish to analyse. '#13#10'Type or paste path here directly, '#13#10'or use the button to the left to select it'
           Top = 9
-          Width = 657
+          Width = 655
           Anchors = [akTop, akLeft, akRight]
           ParentShowHint = False
           ShowHint = True
@@ -1419,10 +1428,10 @@ object MainForm: TMainForm
         end
         object edtFileBName: TEdit
           Left = 128
-          Height = 24
+          Height = 22
           Hint = 'Path to the second file you wish to analyse. '#13#10'Type or paste path here directly, '#13#10'or use the button to the left to select it'
           Top = 72
-          Width = 657
+          Width = 655
           Anchors = [akTop, akLeft, akRight]
           ParentShowHint = False
           ShowHint = True
@@ -1431,20 +1440,20 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxCompareTab: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'After choosing FileA and FileB, tick and set a date and time ahead of current time'#13#10'and then click Compare Now.'
           Top = 132
-          Width = 108
+          Width = 113
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxCompareTabChange
           TabOrder = 7
         end
         object ZVDateTimePickerCompareTab: TZVDateTimePicker
           Left = 128
-          Height = 24
+          Height = 20
           Hint = 'Enter date and time (hours and minutes) '
           Top = 132
-          Width = 138
+          Width = 151
           CenturyFrom = 1941
           MaxDate = 2958465
           MinDate = 42736
@@ -1468,8 +1477,8 @@ object MainForm: TMainForm
     end
     object TabSheet6: TTabSheet
       Caption = 'Compare Two Folders'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 643
+      ClientWidth = 987
       OnContextPopup = TabSheet6ContextPopup
       ParentShowHint = False
       object GroupBox2: TGroupBox
@@ -1479,12 +1488,12 @@ object MainForm: TMainForm
         AnchorSideRight.Side = asrBottom
         Left = 128
         Height = 177
-        Top = 369
-        Width = 837
+        Top = 439
+        Width = 839
         Anchors = [akLeft, akRight, akBottom]
         Caption = 'Summary'
-        ClientHeight = 156
-        ClientWidth = 833
+        ClientHeight = 154
+        ClientWidth = 831
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1512,8 +1521,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1529,22 +1538,22 @@ object MainForm: TMainForm
       end
       object GroupBox1: TGroupBox
         Left = 128
-        Height = 337
+        Height = 407
         Top = 16
-        Width = 837
+        Width = 839
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Compare two folders'
-        ClientHeight = 316
-        ClientWidth = 833
+        ClientHeight = 384
+        ClientWidth = 831
         DragMode = dmAutomatic
         Font.Height = -13
         ParentFont = False
         TabOrder = 0
         object lblStatusA: TLabel
           Left = 8
-          Height = 13
+          Height = 16
           Top = 336
-          Width = 43
+          Width = 49
           Caption = 'Status: '
           Font.Style = [fsBold]
           ParentColor = False
@@ -1583,10 +1592,10 @@ object MainForm: TMainForm
         end
         object ZVDateTimePickerCompareDirsTab: TZVDateTimePicker
           Left = 347
-          Height = 24
+          Height = 20
           Hint = 'Enter date and time (hours and minutes) '
           Top = 200
-          Width = 138
+          Width = 151
           CenturyFrom = 1941
           MaxDate = 2958465
           MinDate = 42736
@@ -1608,10 +1617,10 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxCompareDirsTab: TCheckBox
           Left = 347
-          Height = 20
+          Height = 18
           Hint = 'After choosing FolderA and FolderB, set a date and '#13#10'time ahead of current time and then click Compare Now.'
           Top = 168
-          Width = 108
+          Width = 113
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxCompareTwoDirectoriesTabChange
           TabOrder = 2
@@ -1619,8 +1628,8 @@ object MainForm: TMainForm
         object StatusBar6: TStatusBar
           Left = 8
           Height = 23
-          Top = 292
-          Width = 807
+          Top = 357
+          Width = 805
           Align = alNone
           Anchors = [akLeft, akRight]
           AutoSize = False
@@ -1663,7 +1672,7 @@ object MainForm: TMainForm
           Left = 104
           Height = 16
           Top = 5
-          Width = 87
+          Width = 93
           Caption = 'Select Folder A'
           ParentColor = False
         end
@@ -1671,7 +1680,7 @@ object MainForm: TMainForm
           Left = 608
           Height = 16
           Top = 5
-          Width = 86
+          Width = 92
           Caption = 'Select Folder B'
           ParentColor = False
         end
@@ -1679,7 +1688,7 @@ object MainForm: TMainForm
           Left = 520
           Height = 16
           Top = 275
-          Width = 90
+          Width = 95
           BorderSpacing.Left = 5
           Caption = '# Files in Fol B:'
           ParentColor = False
@@ -1691,7 +1700,7 @@ object MainForm: TMainForm
           Left = 648
           Height = 16
           Top = 275
-          Width = 20
+          Width = 21
           Caption = '  ...'
           ParentColor = False
         end
@@ -1714,7 +1723,7 @@ object MainForm: TMainForm
           Left = 8
           Height = 16
           Top = 275
-          Width = 91
+          Width = 97
           Caption = '# Files in Fol A:'
           ParentColor = False
         end
@@ -1728,10 +1737,10 @@ object MainForm: TMainForm
         end
         object cbUNCModeCompFolders: TCheckBox
           Left = 347
-          Height = 20
+          Height = 18
           Hint = 'For Windows users, if ticked, two UNC path'#13#10'fields will allow the user to compare two '#13#10'network paths'
           Top = 72
-          Width = 85
+          Width = 92
           Caption = 'UNC Mode?'
           OnChange = cbUNCModeCompFoldersChange
           ParentShowHint = False
@@ -1740,7 +1749,7 @@ object MainForm: TMainForm
         end
         object edtUNCPathCompareA: TEdit
           Left = 8
-          Height = 24
+          Height = 22
           Top = 32
           Width = 300
           OnChange = edtUNCPathCompareAChange
@@ -1750,7 +1759,7 @@ object MainForm: TMainForm
         end
         object edtUNCPathCompareB: TEdit
           Left = 520
-          Height = 24
+          Height = 22
           Top = 32
           Width = 300
           OnChange = edtUNCPathCompareBChange
@@ -1760,10 +1769,10 @@ object MainForm: TMainForm
         end
         object cbSaveComparisons: TCheckBox
           Left = 347
-          Height = 20
+          Height = 18
           Hint = 'Save the results of the comparison.'#13#10'Filenames, hash values etc will be '#13#10'auto-saved to a CSV file in the location'#13#10'of where QuickHash is running from.'
           Top = 102
-          Width = 91
+          Width = 99
           Caption = 'Log Results?'
           Checked = True
           OnChange = cbSaveComparisonsChange
@@ -1774,10 +1783,10 @@ object MainForm: TMainForm
         end
         object cbOverrideFileCountDiffer: TCheckBox
           Left = 347
-          Height = 20
+          Height = 18
           Hint = 'If the file count of both folders are different'#13#10'proceed anyway to hash all the files in both'#13#10'(''Save Results?'' must be enabled for this feature)'
           Top = 136
-          Width = 142
+          Width = 157
           Caption = 'Cont. if count differs?'
           OnChange = cbOverrideFileCountDifferChange
           ParentShowHint = False
@@ -1839,8 +1848,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 108
-        ClientWidth = 100
+        ClientHeight = 106
+        ClientWidth = 96
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1861,8 +1870,8 @@ object MainForm: TMainForm
         Width = 847
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Base64 Decoder and Hasher'
-        ClientHeight = 553
-        ClientWidth = 843
+        ClientHeight = 551
+        ClientWidth = 839
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -2011,10 +2020,10 @@ object MainForm: TMainForm
     AnchorSideRight.Side = asrBottom
     Cursor = crHandPoint
     Left = 736
-    Height = 13
+    Height = 16
     Hint = 'Click to open URL in browser'
     Top = 1
-    Width = 170
+    Width = 207
     BorderSpacing.Right = 10
     Caption = 'http://www.quickhash-gui.org'
     Font.Color = clBlue

--- a/unit2.lfm
+++ b/unit2.lfm
@@ -1,12 +1,12 @@
 object MainForm: TMainForm
-  Left = 284
-  Height = 720
-  Top = 161
-  Width = 1025
+  Left = 341
+  Height = 730
+  Top = 171
+  Width = 1023
   AllowDropFiles = True
-  Caption = 'QuickHash v3.0.0 (Jan 2018) - The easy and convenient way to hash data in Linux, OSX and Windows'
-  ClientHeight = 720
-  ClientWidth = 1025
+  Caption = 'QuickHash v3.0.1 (Jan 2018) - The easy and convenient way to hash data in Linux, OSX and Windows'
+  ClientHeight = 711
+  ClientWidth = 1023
   Menu = MainMenu1
   OnClose = FormClose
   OnCreate = FormCreate
@@ -16,30 +16,30 @@ object MainForm: TMainForm
   LCLVersion = '1.6.4.0'
   object PageControl1: TPageControl
     Left = 16
-    Height = 682
+    Height = 673
     Top = 24
-    Width = 993
-    ActivePage = TabSheet2
+    Width = 991
+    ActivePage = TabSheet1
     Anchors = [akTop, akLeft, akRight, akBottom]
     ParentShowHint = False
     ShowHint = True
-    TabIndex = 1
+    TabIndex = 0
     TabOrder = 0
     object TabSheet1: TTabSheet
       Hint = 'Hash portions of text'
       Caption = 'Te&xt'
-      ClientHeight = 643
-      ClientWidth = 987
+      ClientHeight = 647
+      ClientWidth = 983
       OnContextPopup = TabSheet1ContextPopup
       ParentShowHint = False
       object TextHashingGroupBox: TGroupBox
         Left = 120
         Height = 534
         Top = 10
-        Width = 851
+        Width = 847
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Text Hashing'
-        ClientHeight = 511
+        ClientHeight = 513
         ClientWidth = 843
         Color = clForm
         Font.Height = -13
@@ -99,7 +99,7 @@ object MainForm: TMainForm
         end
         object lbleExpectedHashText: TLabeledEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated hash matches the computed hash.'#13#10'To resume normal behaviour, return value '#13#10'to ''...'' (3 dots only)'#13#10'It expects you to paste hash values '#13#10'of the correct length'
           Top = 368
           Width = 822
@@ -126,8 +126,8 @@ object MainForm: TMainForm
           Top = 208
           Width = 448
           Caption = 'Line-By-Line Hashing Options'
-          ClientHeight = 97
-          ClientWidth = 440
+          ClientHeight = 99
+          ClientWidth = 444
           TabOrder = 3
           object btnFLBL: TButton
             Left = 8
@@ -155,10 +155,10 @@ object MainForm: TMainForm
           end
           object cbToggleInputDataToOutputFile: TCheckBox
             Left = 184
-            Height = 18
+            Height = 20
             Hint = 'If unticked, source text (including '#13#10'hashes) will be output. '#13#10'If ticked, only the computed'#13#10'hashes will be output.'
             Top = 16
-            Width = 213
+            Width = 192
             Caption = 'Source text INcluded in output'
             OnChange = cbToggleInputDataToOutputFileChange
             ParentShowHint = False
@@ -168,9 +168,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseTEXT: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Top = 472
-          Width = 93
+          Width = 88
           Caption = 'Switch case'
           OnChange = cbFlipCaseTEXTChange
           TabOrder = 4
@@ -228,8 +228,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -252,8 +252,8 @@ object MainForm: TMainForm
         Top = 152
         Width = 96
         Caption = 'System RAM'
-        ClientHeight = 58
-        ClientWidth = 88
+        ClientHeight = 60
+        ClientWidth = 92
         Font.Height = -13
         ParentFont = False
         TabOrder = 2
@@ -270,18 +270,18 @@ object MainForm: TMainForm
     object TabSheet2: TTabSheet
       Hint = 'Hash a single file (useful for hashing disks in Linux)'
       Caption = 'F&ile'
-      ClientHeight = 643
-      ClientWidth = 987
+      ClientHeight = 637
+      ClientWidth = 985
       ParentShowHint = False
       object FileHashingGroupBox: TGroupBox
         Left = 120
         Height = 398
         Top = 10
-        Width = 852
+        Width = 850
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Single File Hashing'
-        ClientHeight = 375
-        ClientWidth = 844
+        ClientHeight = 377
+        ClientWidth = 846
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -292,7 +292,7 @@ object MainForm: TMainForm
           Left = 552
           Height = 32
           Top = 47
-          Width = 294
+          Width = 264
           Caption = 'As root, this section can be used to hash disks'#10'e.g. /dev/sdX or /dev/sdaX, or /dev/hdX'
           ParentColor = False
           WordWrap = True
@@ -315,9 +315,9 @@ object MainForm: TMainForm
         end
         object edtFileNameToBeHashed: TEdit
           Left = 6
-          Height = 22
+          Height = 24
           Top = 96
-          Width = 824
+          Width = 826
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           ReadOnly = True
@@ -326,10 +326,10 @@ object MainForm: TMainForm
         end
         object btnHashFile: TButton
           Left = 6
-          Height = 20
+          Height = 23
           Hint = 'Choose a single file to hash (or Linux physical device e.g. /dev/sda)'
           Top = 64
-          Width = 87
+          Width = 83
           AutoSize = True
           Caption = 'Select &File'
           Color = 8454016
@@ -342,16 +342,16 @@ object MainForm: TMainForm
         end
         object StatusBar1: TStatusBar
           Left = 0
-          Height = 15
-          Top = 360
-          Width = 844
+          Height = 20
+          Top = 357
+          Width = 846
           Panels = <>
         end
         object lblDragAndDropNudge: TLabel
           Left = 112
           Height = 16
           Top = 64
-          Width = 127
+          Width = 115
           Caption = 'or drag n drop a file'
           ParentColor = False
         end
@@ -359,7 +359,7 @@ object MainForm: TMainForm
           Left = 6
           Height = 58
           Top = 136
-          Width = 824
+          Width = 826
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           Lines.Strings = (
@@ -377,10 +377,10 @@ object MainForm: TMainForm
         end
         object lbleExpectedHash: TLabeledEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated file hash matches it, or not. '
           Top = 264
-          Width = 822
+          Width = 824
           Anchors = [akTop, akLeft, akRight]
           EditLabel.AnchorSideLeft.Control = lbleExpectedHash
           EditLabel.AnchorSideRight.Control = lbleExpectedHash
@@ -389,7 +389,7 @@ object MainForm: TMainForm
           EditLabel.Left = 8
           EditLabel.Height = 16
           EditLabel.Top = 245
-          EditLabel.Width = 822
+          EditLabel.Width = 824
           EditLabel.Caption = 'Expected Hash Value (paste from other utility before or after file hashing)'
           EditLabel.ParentColor = False
           MaxLength = 128
@@ -407,10 +407,10 @@ object MainForm: TMainForm
         end
         object ZVDateTimePickerFileTab: TZVDateTimePicker
           Left = 8
-          Height = 20
+          Height = 24
           Hint = 'Enter date and time (hours and minutes) '#13#10'to start the process. Must be in the future!'
           Top = 32
-          Width = 151
+          Width = 138
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -434,10 +434,10 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileTab: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the file to hash.'
           Top = 8
-          Width = 113
+          Width = 108
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileTabChange
           ParentShowHint = False
@@ -474,9 +474,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseFILE: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Top = 208
-          Width = 93
+          Width = 88
           Caption = 'Switch case'
           OnChange = cbFlipCaseFILEChange
           TabOrder = 9
@@ -497,8 +497,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -517,18 +517,18 @@ object MainForm: TMainForm
     object TabSheet3: TTabSheet
       Hint = 'Compute hashes for multiple files in a directory'#13#10'recursively, or just those in the root of the directory'
       Caption = 'FileS'
-      ClientHeight = 643
-      ClientWidth = 987
+      ClientHeight = 647
+      ClientWidth = 983
       ParentShowHint = False
       ShowHint = True
       object DirectoryHashingGroupBox: TGroupBox
         Left = 120
-        Height = 617
+        Height = 621
         Top = 10
-        Width = 857
+        Width = 853
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Hash all files in chosen directory - recursive by default'
-        ClientHeight = 594
+        ClientHeight = 600
         ClientWidth = 849
         Color = clForm
         Font.Height = -13
@@ -549,10 +549,10 @@ object MainForm: TMainForm
         end
         object btnRecursiveDirectoryHashing: TButton
           Left = 8
-          Height = 20
+          Height = 23
           Hint = 'All files and subdirectories below the chosen '#10'directory will be hashed, subject to selected'#10'options. Recursive by default.'
           Top = 96
-          Width = 109
+          Width = 99
           AutoSize = True
           Caption = 'Select &Folder'
           Color = 8454016
@@ -565,7 +565,7 @@ object MainForm: TMainForm
         end
         object DirSelectedField: TEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'The chosen parent directory'
           Top = 136
           Width = 822
@@ -588,17 +588,17 @@ object MainForm: TMainForm
           Left = 520
           Height = 16
           Top = 56
-          Width = 95
+          Width = 233
           Anchors = [akTop, akLeft, akRight]
           Caption = '% Complete:'
           ParentColor = False
         end
         object btnClipboardResults: TButton
           Left = 224
-          Height = 20
+          Height = 26
           Hint = 'Press this to copy entire grid content to RAM'
           Top = 96
-          Width = 90
+          Width = 80
           AutoSize = True
           Caption = 'Clipboard'
           Enabled = False
@@ -609,10 +609,10 @@ object MainForm: TMainForm
         end
         object btnStopScan1: TButton
           Left = 152
-          Height = 20
+          Height = 23
           Hint = 'Click to abort the hash as soon as the'#10'current file hashing action completes. '
           Top = 96
-          Width = 70
+          Width = 48
           AutoSize = True
           Caption = 'S&top'
           OnClick = btnStopScan1Click
@@ -621,18 +621,18 @@ object MainForm: TMainForm
         end
         object chkRecursiveDirOverride: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Hash files just in the root of the chosen folder'#13#10'Sub-folders will be ignored. '
           Top = 8
-          Width = 181
+          Width = 162
           Caption = 'Ignoring sub-directories?'
           TabOrder = 1
         end
         object Label5: TLabel
           Left = 110
-          Height = 23
+          Height = 24
           Top = 312
-          Width = 653
+          Width = 606
           Caption = 'This area will be populated once the scan is complete...please wait!'
           Font.Height = -20
           ParentColor = False
@@ -645,7 +645,7 @@ object MainForm: TMainForm
           AnchorSideRight.Side = asrBottom
           Left = 8
           Height = 23
-          Top = 562
+          Top = 568
           Width = 841
           Align = alCustom
           Anchors = [akLeft, akRight]
@@ -658,7 +658,7 @@ object MainForm: TMainForm
           Left = 686
           Height = 17
           Top = 6
-          Width = 156
+          Width = 163
           AutoSize = False
           Caption = '...'
           ParentColor = False
@@ -716,16 +716,16 @@ object MainForm: TMainForm
         end
         object chkHiddenFiles: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Tick to have files in hidden folders hashed. '#13#10'Hidden files are hashed by default anyway '#13#10'but hidden folders, ergo their contents, are not found by default.'
           Top = 64
-          Width = 144
+          Width = 130
           Caption = 'Hidden folders too?'
           TabOrder = 6
         end
         object FileMaskField2: TEdit
           Left = 288
-          Height = 22
+          Height = 24
           Hint = 'Use an asterix, full stop and the file type '#10'extension, seperated by a semi-colon.'#10'NO space characters'
           Top = 36
           Width = 200
@@ -737,19 +737,19 @@ object MainForm: TMainForm
         end
         object FileTypeMaskCheckBox2: TCheckBox
           Left = 288
-          Height = 18
+          Height = 20
           Hint = 'Select file type masks (e.g. *.doc;*.pdf)'#13#10'Remember that JPG and jpg are different'#13#10'file names on Linux and OSX!!'
           Top = 8
-          Width = 134
+          Width = 123
           Caption = 'Choose file types?'
           OnChange = FileTypeMaskCheckBox2Change
           TabOrder = 8
         end
         object ZVDateTimePickerFileSTab: TZVDateTimePicker
           Left = 128
-          Height = 20
+          Height = 24
           Top = 36
-          Width = 151
+          Width = 138
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -771,17 +771,17 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileSTab: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the directory to hash.'
           Top = 36
-          Width = 113
+          Width = 108
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileSTabChange
           TabOrder = 10
         end
         object RecursiveDisplayGrid1: TDBGrid
           Left = 8
-          Height = 370
+          Height = 376
           Top = 176
           Width = 843
           Anchors = [akTop, akLeft, akRight, akBottom]
@@ -815,9 +815,9 @@ object MainForm: TMainForm
         end
         object cbLoadHashList: TCheckBox
           Left = 288
-          Height = 18
+          Height = 20
           Top = 64
-          Width = 108
+          Width = 98
           Caption = 'Load HashList'
           OnChange = cbLoadHashListChange
           TabOrder = 13
@@ -849,8 +849,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -886,8 +886,8 @@ object MainForm: TMainForm
         Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Hash files in chosen directory, copy them, and re-hash the copied files (recursive by default) '
-        ClientHeight = 573
-        ClientWidth = 837
+        ClientHeight = 575
+        ClientWidth = 841
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -1259,8 +1259,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1294,8 +1294,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1318,8 +1318,8 @@ object MainForm: TMainForm
         Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Choose two files and click ''Compare Files'''
-        ClientHeight = 273
-        ClientWidth = 837
+        ClientHeight = 275
+        ClientWidth = 841
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1492,8 +1492,8 @@ object MainForm: TMainForm
         Width = 839
         Anchors = [akLeft, akRight, akBottom]
         Caption = 'Summary'
-        ClientHeight = 154
-        ClientWidth = 831
+        ClientHeight = 156
+        ClientWidth = 835
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1521,8 +1521,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1543,8 +1543,8 @@ object MainForm: TMainForm
         Width = 839
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Compare two folders'
-        ClientHeight = 384
-        ClientWidth = 831
+        ClientHeight = 386
+        ClientWidth = 835
         DragMode = dmAutomatic
         Font.Height = -13
         ParentFont = False
@@ -1848,8 +1848,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1870,8 +1870,8 @@ object MainForm: TMainForm
         Width = 847
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Base64 Decoder and Hasher'
-        ClientHeight = 551
-        ClientWidth = 839
+        ClientHeight = 553
+        ClientWidth = 843
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -2020,10 +2020,10 @@ object MainForm: TMainForm
     AnchorSideRight.Side = asrBottom
     Cursor = crHandPoint
     Left = 736
-    Height = 16
+    Height = 13
     Hint = 'Click to open URL in browser'
     Top = 1
-    Width = 207
+    Width = 170
     BorderSpacing.Right = 10
     Caption = 'http://www.quickhash-gui.org'
     Font.Color = clBlue

--- a/unit2.lfm
+++ b/unit2.lfm
@@ -1,11 +1,11 @@
 object MainForm: TMainForm
-  Left = 341
-  Height = 730
-  Top = 171
+  Left = 221
+  Height = 733
+  Top = 69
   Width = 1023
   AllowDropFiles = True
-  Caption = 'QuickHash v3.0.1 (Jan 2018) - The easy and convenient way to hash data in Linux, OSX and Windows'
-  ClientHeight = 730
+  Caption = 'QuickHash v3.0.1 (Feb 2018) - The easy and convenient way to hash data in Linux, OSX and Windows'
+  ClientHeight = 714
   ClientWidth = 1023
   Menu = MainMenu1
   OnClose = FormClose
@@ -16,7 +16,7 @@ object MainForm: TMainForm
   LCLVersion = '1.6.4.0'
   object PageControl1: TPageControl
     Left = 16
-    Height = 692
+    Height = 676
     Top = 24
     Width = 991
     ActivePage = TabSheet1
@@ -28,19 +28,19 @@ object MainForm: TMainForm
     object TabSheet1: TTabSheet
       Hint = 'Hash portions of text'
       Caption = 'Te&xt'
-      ClientHeight = 653
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       OnContextPopup = TabSheet1ContextPopup
       ParentShowHint = False
       object TextHashingGroupBox: TGroupBox
         Left = 120
         Height = 534
         Top = 10
-        Width = 849
+        Width = 847
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Text Hashing'
-        ClientHeight = 511
-        ClientWidth = 841
+        ClientHeight = 513
+        ClientWidth = 843
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -51,7 +51,7 @@ object MainForm: TMainForm
           Height = 183
           Hint = 'Type or paste and watch hash value change.'#13#10'For amounts larger than several hundred Kb, save'#13#10'data to a file and use File Hashing instead. '
           Top = 9
-          Width = 819
+          Width = 821
           Anchors = [akTop, akLeft, akRight]
           Lines.Strings = (
             'Type or paste text here - hash will update as you type'
@@ -78,7 +78,7 @@ object MainForm: TMainForm
           Height = 56
           Hint = 'This is the hash of ALL THE TEXT in the textarea above'#13#10'For line-by-line analysis, use the button'#13#10#13#10'The hash value can be copied from here'#13#10'to clipboard (highlight and press Ctrl + C or right click ''Copy'''
           Top = 408
-          Width = 819
+          Width = 821
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           Font.Height = -13
@@ -103,10 +103,10 @@ object MainForm: TMainForm
         end
         object lbleExpectedHashText: TLabeledEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated hash matches the computed hash.'#13#10'To resume normal behaviour, return value '#13#10'to ''...'' (3 dots only)'#13#10'It expects you to paste hash values '#13#10'of the correct length'
           Top = 368
-          Width = 820
+          Width = 822
           Anchors = [akTop, akLeft, akRight]
           EditLabel.AnchorSideLeft.Control = lbleExpectedHashText
           EditLabel.AnchorSideRight.Control = lbleExpectedHashText
@@ -115,7 +115,7 @@ object MainForm: TMainForm
           EditLabel.Left = 8
           EditLabel.Height = 16
           EditLabel.Top = 349
-          EditLabel.Width = 820
+          EditLabel.Width = 822
           EditLabel.Caption = 'Expected Hash Value (clear, then paste value from other utility)'
           EditLabel.ParentColor = False
           ParentShowHint = False
@@ -130,8 +130,8 @@ object MainForm: TMainForm
           Top = 208
           Width = 448
           Caption = 'Line-By-Line Hashing Options'
-          ClientHeight = 97
-          ClientWidth = 440
+          ClientHeight = 99
+          ClientWidth = 444
           TabOrder = 3
           object btnFLBL: TButton
             Left = 8
@@ -159,10 +159,10 @@ object MainForm: TMainForm
           end
           object cbToggleInputDataToOutputFile: TCheckBox
             Left = 184
-            Height = 18
+            Height = 20
             Hint = 'If unticked, source text (including '#13#10'hashes) will be output. '#13#10'If ticked, only the computed'#13#10'hashes will be output.'
             Top = 16
-            Width = 213
+            Width = 192
             Caption = 'Source text INcluded in output'
             OnChange = cbToggleInputDataToOutputFileChange
             ParentShowHint = False
@@ -172,9 +172,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseTEXT: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Top = 472
-          Width = 93
+          Width = 88
           Caption = 'Switch case'
           OnChange = cbFlipCaseTEXTChange
           TabOrder = 4
@@ -232,8 +232,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -256,8 +256,8 @@ object MainForm: TMainForm
         Top = 152
         Width = 96
         Caption = 'System RAM'
-        ClientHeight = 58
-        ClientWidth = 88
+        ClientHeight = 60
+        ClientWidth = 92
         Font.Height = -13
         ParentFont = False
         TabOrder = 2
@@ -274,18 +274,18 @@ object MainForm: TMainForm
     object TabSheet2: TTabSheet
       Hint = 'Hash a single file (useful for hashing disks in Linux)'
       Caption = 'F&ile'
-      ClientHeight = 653
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       ParentShowHint = False
       object FileHashingGroupBox: TGroupBox
         Left = 120
         Height = 398
         Top = 10
-        Width = 850
+        Width = 848
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Single File Hashing'
-        ClientHeight = 375
-        ClientWidth = 842
+        ClientHeight = 377
+        ClientWidth = 844
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -296,7 +296,7 @@ object MainForm: TMainForm
           Left = 552
           Height = 32
           Top = 47
-          Width = 294
+          Width = 264
           Caption = 'As root, this section can be used to hash disks'#10'e.g. /dev/sdX or /dev/sdaX, or /dev/hdX'
           ParentColor = False
           WordWrap = True
@@ -319,9 +319,9 @@ object MainForm: TMainForm
         end
         object edtFileNameToBeHashed: TEdit
           Left = 6
-          Height = 22
+          Height = 24
           Top = 96
-          Width = 826
+          Width = 824
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           ReadOnly = True
@@ -330,10 +330,10 @@ object MainForm: TMainForm
         end
         object btnHashFile: TButton
           Left = 6
-          Height = 20
+          Height = 23
           Hint = 'Choose a single file to hash (or Linux physical device e.g. /dev/sda)'
           Top = 64
-          Width = 91
+          Width = 83
           AutoSize = True
           Caption = 'Select &File'
           Color = 8454016
@@ -346,16 +346,16 @@ object MainForm: TMainForm
         end
         object StatusBar1: TStatusBar
           Left = 0
-          Height = 15
-          Top = 360
-          Width = 842
+          Height = 20
+          Top = 357
+          Width = 844
           Panels = <>
         end
         object lblDragAndDropNudge: TLabel
           Left = 112
           Height = 16
           Top = 64
-          Width = 127
+          Width = 115
           Caption = 'or drag n drop a file'
           ParentColor = False
         end
@@ -363,7 +363,7 @@ object MainForm: TMainForm
           Left = 6
           Height = 58
           Top = 136
-          Width = 826
+          Width = 824
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           Lines.Strings = (
@@ -383,10 +383,10 @@ object MainForm: TMainForm
         end
         object lbleExpectedHash: TLabeledEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated file hash matches it, or not. '
           Top = 264
-          Width = 824
+          Width = 822
           Anchors = [akTop, akLeft, akRight]
           EditLabel.AnchorSideLeft.Control = lbleExpectedHash
           EditLabel.AnchorSideRight.Control = lbleExpectedHash
@@ -395,7 +395,7 @@ object MainForm: TMainForm
           EditLabel.Left = 8
           EditLabel.Height = 16
           EditLabel.Top = 245
-          EditLabel.Width = 824
+          EditLabel.Width = 822
           EditLabel.Caption = 'Expected Hash Value (paste from other utility before or after file hashing)'
           EditLabel.ParentColor = False
           MaxLength = 128
@@ -413,10 +413,10 @@ object MainForm: TMainForm
         end
         object ZVDateTimePickerFileTab: TZVDateTimePicker
           Left = 8
-          Height = 20
+          Height = 24
           Hint = 'Enter date and time (hours and minutes) '#13#10'to start the process. Must be in the future!'
           Top = 32
-          Width = 151
+          Width = 138
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -440,10 +440,10 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileTab: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the file to hash.'
           Top = 8
-          Width = 113
+          Width = 108
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileTabChange
           ParentShowHint = False
@@ -480,9 +480,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseFILE: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Top = 208
-          Width = 93
+          Width = 88
           Caption = 'Switch case'
           OnChange = cbFlipCaseFILEChange
           TabOrder = 9
@@ -503,8 +503,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -523,19 +523,19 @@ object MainForm: TMainForm
     object TabSheet3: TTabSheet
       Hint = 'Compute hashes for multiple files in a directory'#13#10'recursively, or just those in the root of the directory'
       Caption = 'FileS'
-      ClientHeight = 653
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       ParentShowHint = False
       ShowHint = True
       object DirectoryHashingGroupBox: TGroupBox
         Left = 120
-        Height = 627
+        Height = 624
         Top = 10
-        Width = 855
+        Width = 853
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Hash all files in chosen directory - recursive by default'
-        ClientHeight = 604
-        ClientWidth = 847
+        ClientHeight = 603
+        ClientWidth = 849
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -555,10 +555,10 @@ object MainForm: TMainForm
         end
         object btnRecursiveDirectoryHashing: TButton
           Left = 8
-          Height = 20
+          Height = 23
           Hint = 'All files and subdirectories below the chosen '#10'directory will be hashed, subject to selected'#10'options. Recursive by default.'
           Top = 96
-          Width = 105
+          Width = 99
           AutoSize = True
           Caption = 'Select &Folder'
           Color = 8454016
@@ -571,10 +571,10 @@ object MainForm: TMainForm
         end
         object DirSelectedField: TEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'The chosen parent directory'
           Top = 136
-          Width = 820
+          Width = 818
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           TabOrder = 0
@@ -594,17 +594,17 @@ object MainForm: TMainForm
           Left = 520
           Height = 16
           Top = 56
-          Width = 231
+          Width = 229
           Anchors = [akTop, akLeft, akRight]
           Caption = '% Complete:'
           ParentColor = False
         end
         object btnClipboardResults: TButton
           Left = 224
-          Height = 20
+          Height = 26
           Hint = 'Press this to copy entire grid content to RAM'
           Top = 96
-          Width = 86
+          Width = 80
           AutoSize = True
           Caption = 'Clipboard'
           Enabled = False
@@ -615,10 +615,10 @@ object MainForm: TMainForm
         end
         object btnStopScan1: TButton
           Left = 152
-          Height = 20
+          Height = 23
           Hint = 'Click to abort the hash as soon as the'#10'current file hashing action completes. '
           Top = 96
-          Width = 70
+          Width = 48
           AutoSize = True
           Caption = 'S&top'
           OnClick = btnStopScan1Click
@@ -627,18 +627,18 @@ object MainForm: TMainForm
         end
         object chkRecursiveDirOverride: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Hash files just in the root of the chosen folder'#13#10'Sub-folders will be ignored. '
           Top = 8
-          Width = 181
+          Width = 162
           Caption = 'Ignoring sub-directories?'
           TabOrder = 1
         end
         object Label5: TLabel
           Left = 110
-          Height = 23
+          Height = 24
           Top = 312
-          Width = 653
+          Width = 606
           Caption = 'This area will be populated once the scan is complete...please wait!'
           Font.Height = -20
           ParentColor = False
@@ -651,8 +651,8 @@ object MainForm: TMainForm
           AnchorSideRight.Side = asrBottom
           Left = 8
           Height = 23
-          Top = 572
-          Width = 839
+          Top = 569
+          Width = 841
           Align = alCustom
           Anchors = [akLeft, akRight]
           AutoSize = False
@@ -675,7 +675,7 @@ object MainForm: TMainForm
           Left = 686
           Height = 16
           Top = 56
-          Width = 161
+          Width = 163
           Anchors = [akTop, akLeft, akRight]
           Caption = '...'
           ParentColor = False
@@ -722,16 +722,16 @@ object MainForm: TMainForm
         end
         object chkHiddenFiles: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Tick to have files in hidden folders hashed. '#13#10'Hidden files are hashed by default anyway '#13#10'but hidden folders, ergo their contents, are not found by default.'
           Top = 64
-          Width = 144
+          Width = 130
           Caption = 'Hidden folders too?'
           TabOrder = 6
         end
         object FileMaskField2: TEdit
           Left = 288
-          Height = 22
+          Height = 24
           Hint = 'Use an asterix, full stop and the file type '#10'extension, seperated by a semi-colon.'#10'NO space characters'
           Top = 36
           Width = 200
@@ -743,19 +743,19 @@ object MainForm: TMainForm
         end
         object FileTypeMaskCheckBox2: TCheckBox
           Left = 288
-          Height = 18
+          Height = 20
           Hint = 'Select file type masks (e.g. *.doc;*.pdf)'#13#10'Remember that JPG and jpg are different'#13#10'file names on Linux and OSX!!'
           Top = 8
-          Width = 134
+          Width = 123
           Caption = 'Choose file types?'
           OnChange = FileTypeMaskCheckBox2Change
           TabOrder = 8
         end
         object ZVDateTimePickerFileSTab: TZVDateTimePicker
           Left = 128
-          Height = 20
+          Height = 24
           Top = 36
-          Width = 151
+          Width = 138
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -777,19 +777,19 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileSTab: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the directory to hash.'
           Top = 36
-          Width = 113
+          Width = 108
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileSTabChange
           TabOrder = 10
         end
         object RecursiveDisplayGrid1: TDBGrid
           Left = 8
-          Height = 380
+          Height = 377
           Top = 176
-          Width = 841
+          Width = 839
           Anchors = [akTop, akLeft, akRight, akBottom]
           Color = clWindow
           Columns = <>
@@ -821,9 +821,9 @@ object MainForm: TMainForm
         end
         object cbLoadHashList: TCheckBox
           Left = 288
-          Height = 18
+          Height = 20
           Top = 64
-          Width = 108
+          Width = 98
           Caption = 'Load HashList'
           OnChange = cbLoadHashListChange
           TabOrder = 13
@@ -855,8 +855,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -881,19 +881,19 @@ object MainForm: TMainForm
     object TabSheet4: TTabSheet
       Hint = 'Choose a directory, have its content hashed, files are copied to destination, and re-hashed.'
       Caption = '&Copy'
-      ClientHeight = 653
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       ParentShowHint = False
       ShowHint = True
       object CopyFilesHashingGroupBox: TGroupBox
         Left = 120
         Height = 596
         Top = 8
-        Width = 843
+        Width = 841
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Hash files in chosen directory, copy them, and re-hash the copied files (recursive by default) '
-        ClientHeight = 573
-        ClientWidth = 835
+        ClientHeight = 575
+        ClientWidth = 837
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -903,18 +903,18 @@ object MainForm: TMainForm
           Left = 8
           Height = 184
           Top = 8
-          Width = 824
+          Width = 822
           Anchors = [akTop, akLeft, akRight]
           ClientHeight = 184
-          ClientWidth = 824
+          ClientWidth = 822
           TabOrder = 3
           OnClick = Panel1CopyAndHashOptionsClick
           object CheckBoxListOfDirsOnly: TCheckBox
             Left = 14
-            Height = 18
+            Height = 20
             Hint = 'Tick to have child directories listed, but no files inside hashed'
-            Top = 1
-            Width = 176
+            Top = 0
+            Width = 161
             Anchors = [akLeft]
             Caption = 'Just LIST sub-directories'
             OnChange = CheckBoxListOfDirsOnlyChange
@@ -922,20 +922,20 @@ object MainForm: TMainForm
           end
           object CheckBoxListOfDirsAndFilesOnly: TCheckBox
             Left = 14
-            Height = 18
+            Height = 20
             Hint = 'Tick to have child directories and files listed, but no files actually hashed'
             Top = 32
-            Width = 233
+            Width = 213
             Caption = 'Just LIST sub-directories and files'
             OnChange = CheckBoxListOfDirsAndFilesOnlyChange
             TabOrder = 1
           end
           object SaveToCSVCheckBox2: TCheckBox
             Left = 256
-            Height = 18
+            Height = 20
             Hint = 'Save results as CSV data (spreadsheet format)'
             Top = 0
-            Width = 138
+            Width = 134
             Caption = 'Save results (CSV)?'
             Checked = True
             State = cbChecked
@@ -943,17 +943,17 @@ object MainForm: TMainForm
           end
           object FileTypeMaskCheckBox1: TCheckBox
             Left = 448
-            Height = 18
+            Height = 20
             Hint = 'Only copy files of a particular type'
             Top = 32
-            Width = 134
+            Width = 123
             Caption = 'Choose file types?'
             OnChange = FileTypeMaskCheckBox1Change
             TabOrder = 4
           end
           object FileMaskField: TEdit
             Left = 464
-            Height = 22
+            Height = 24
             Hint = 'Use an asterix, full stop and the file type '#10'extension, seperated by a semi-colon.'#10'NO space characters'
             Top = 64
             Width = 248
@@ -965,10 +965,10 @@ object MainForm: TMainForm
           end
           object chkNoRecursiveCopy: TCheckBox
             Left = 448
-            Height = 18
+            Height = 20
             Hint = 'Only copy files found in the root of chosen directory'
-            Top = 1
-            Width = 168
+            Top = 0
+            Width = 152
             Anchors = [akLeft]
             Caption = 'Ignore sub-directories?'
             TabOrder = 3
@@ -977,7 +977,7 @@ object MainForm: TMainForm
             Left = 14
             Height = 16
             Top = 72
-            Width = 84
+            Width = 78
             Caption = '# Files in Dir:'
             ParentColor = False
           end
@@ -985,7 +985,7 @@ object MainForm: TMainForm
             Left = 14
             Height = 16
             Top = 104
-            Width = 110
+            Width = 103
             Caption = '# Files Examined:'
             ParentColor = False
           end
@@ -993,7 +993,7 @@ object MainForm: TMainForm
             Left = 14
             Height = 16
             Top = 136
-            Width = 77
+            Width = 75
             Caption = '% Complete:'
             ParentColor = False
           end
@@ -1001,7 +1001,7 @@ object MainForm: TMainForm
             Left = 464
             Height = 16
             Top = 97
-            Width = 73
+            Width = 70
             Caption = 'Start Time: '
             ParentColor = False
           end
@@ -1009,7 +1009,7 @@ object MainForm: TMainForm
             Left = 464
             Height = 16
             Top = 121
-            Width = 71
+            Width = 67
             Caption = 'End Time:  '
             ParentColor = False
           end
@@ -1033,7 +1033,7 @@ object MainForm: TMainForm
             Left = 464
             Height = 16
             Top = 145
-            Width = 78
+            Width = 73
             Caption = 'Time Taken:'
             ParentColor = False
           end
@@ -1067,7 +1067,7 @@ object MainForm: TMainForm
             AnchorSideTop.Control = pbCopy
             AnchorSideTop.Side = asrBottom
             AnchorSideRight.Control = pbCopy
-            Left = 377
+            Left = 376
             Height = 16
             Top = 139
             Width = 12
@@ -1077,20 +1077,20 @@ object MainForm: TMainForm
           end
           object chkNoPathReconstruction: TCheckBox
             Left = 624
-            Height = 18
+            Height = 20
             Hint = 'Files will be copied to the root of your chosen '#10'destination directory. Duplicate file NAMES '#10'will have their names appended with '#10'DuplicatedNameX to avoid filesystem conflicts'
-            Top = 1
-            Width = 141
+            Top = 0
+            Width = 127
             Anchors = [akLeft]
             Caption = 'Don''t rebuild path?'
             TabOrder = 6
           end
           object chkCopyHidden: TCheckBox
             Left = 624
-            Height = 18
+            Height = 20
             Hint = 'If checked, will find hidden directories and files and copy those too'
             Top = 32
-            Width = 136
+            Width = 123
             Caption = 'Copy hidden files?'
             TabOrder = 7
           end
@@ -1104,20 +1104,20 @@ object MainForm: TMainForm
           end
           object lblschedulertickboxCopyTab: TCheckBox
             Left = 256
-            Height = 18
+            Height = 20
             Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the source and destination folders.'#13#10'Hash, copy and hash will start at the specified time'
             Top = 32
-            Width = 113
+            Width = 108
             Caption = 'Start at a time:'
             OnChange = lblschedulertickboxCopyTabChange
             TabOrder = 9
           end
           object ZVDateTimePickerCopyTab: TZVDateTimePicker
             Left = 272
-            Height = 20
+            Height = 24
             Hint = 'Enter date and time (hours and minutes) '
             Top = 64
-            Width = 151
+            Width = 138
             CenturyFrom = 1941
             MaxDate = 73050
             MinDate = 42736
@@ -1164,7 +1164,7 @@ object MainForm: TMainForm
         end
         object Edit2SourcePath: TEdit
           Left = 8
-          Height = 22
+          Height = 24
           Hint = 'Show currently selected source directory'#13#10'Switch to UNC path by ticking "UNC Mode?"'
           Top = 216
           Width = 365
@@ -1177,7 +1177,7 @@ object MainForm: TMainForm
         end
         object Edit3DestinationPath: TEdit
           Left = 480
-          Height = 22
+          Height = 24
           Hint = 'Show currently selected destination directory'#13#10'Switch to UNC path by ticking "UNC Mode?"'
           Top = 216
           Width = 357
@@ -1190,9 +1190,9 @@ object MainForm: TMainForm
         end
         object StatusBar3: TStatusBar
           Left = 0
-          Height = 15
-          Top = 558
-          Width = 835
+          Height = 20
+          Top = 555
+          Width = 837
           Panels = <>
           ParentShowHint = False
         end
@@ -1241,10 +1241,10 @@ object MainForm: TMainForm
         end
         object chkUNCMode: TCheckBox
           Left = 384
-          Height = 18
+          Height = 20
           Hint = 'Tick to enter UNC network path '#13#10'instead of using treeview selection'
           Top = 216
-          Width = 92
+          Width = 85
           Caption = 'UNC Mode?'
           OnChange = chkUNCModeChange
           TabOrder = 8
@@ -1265,8 +1265,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1283,8 +1283,8 @@ object MainForm: TMainForm
     end
     object TabSheet7: TTabSheet
       Caption = 'Compare Two Files'
-      ClientHeight = 653
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       object AlgorithmChoiceRadioBox5: TRadioGroup
         Left = 16
         Height = 129
@@ -1300,8 +1300,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1321,11 +1321,11 @@ object MainForm: TMainForm
         Left = 120
         Height = 296
         Top = 10
-        Width = 843
+        Width = 841
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Choose two files and click ''Compare Files'''
-        ClientHeight = 273
-        ClientWidth = 835
+        ClientHeight = 275
+        ClientWidth = 837
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1361,7 +1361,7 @@ object MainForm: TMainForm
           Left = 130
           Height = 16
           Top = 176
-          Width = 43
+          Width = 40
           Caption = 'Result:'
           ParentColor = False
         end
@@ -1393,9 +1393,9 @@ object MainForm: TMainForm
         end
         object lblHashMatchResult: TLabel
           Left = 180
-          Height = 16
+          Height = 13
           Top = 176
-          Width = 10
+          Width = 9
           Caption = '...'
           Font.Style = [fsBold]
           ParentColor = False
@@ -1415,17 +1415,17 @@ object MainForm: TMainForm
           AnchorSideLeft.Control = GroupBox4
           AnchorSideRight.Control = GroupBox4
           Left = 0
-          Height = 15
-          Top = 258
-          Width = 835
+          Height = 20
+          Top = 255
+          Width = 837
           Panels = <>
         end
         object edtFileAName: TEdit
           Left = 128
-          Height = 22
+          Height = 24
           Hint = 'Path to the file you wish to analyse. '#13#10'Type or paste path here directly, '#13#10'or use the button to the left to select it'
           Top = 9
-          Width = 653
+          Width = 651
           Anchors = [akTop, akLeft, akRight]
           ParentShowHint = False
           ShowHint = True
@@ -1434,10 +1434,10 @@ object MainForm: TMainForm
         end
         object edtFileBName: TEdit
           Left = 128
-          Height = 22
+          Height = 24
           Hint = 'Path to the second file you wish to analyse. '#13#10'Type or paste path here directly, '#13#10'or use the button to the left to select it'
           Top = 72
-          Width = 653
+          Width = 651
           Anchors = [akTop, akLeft, akRight]
           ParentShowHint = False
           ShowHint = True
@@ -1446,20 +1446,20 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxCompareTab: TCheckBox
           Left = 8
-          Height = 18
+          Height = 20
           Hint = 'After choosing FileA and FileB, tick and set a date and time ahead of current time'#13#10'and then click Compare Now.'
           Top = 132
-          Width = 113
+          Width = 108
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxCompareTabChange
           TabOrder = 7
         end
         object ZVDateTimePickerCompareTab: TZVDateTimePicker
           Left = 128
-          Height = 20
+          Height = 24
           Hint = 'Enter date and time (hours and minutes) '
           Top = 132
-          Width = 151
+          Width = 138
           CenturyFrom = 1941
           MaxDate = 2958465
           MinDate = 42736
@@ -1483,8 +1483,8 @@ object MainForm: TMainForm
     end
     object TabSheet6: TTabSheet
       Caption = 'Compare Two Folders'
-      ClientHeight = 653
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       OnContextPopup = TabSheet6ContextPopup
       ParentShowHint = False
       object GroupBox2: TGroupBox
@@ -1494,12 +1494,12 @@ object MainForm: TMainForm
         AnchorSideRight.Side = asrBottom
         Left = 128
         Height = 177
-        Top = 449
-        Width = 837
+        Top = 446
+        Width = 835
         Anchors = [akLeft, akRight, akBottom]
         Caption = 'Summary'
-        ClientHeight = 154
-        ClientWidth = 829
+        ClientHeight = 156
+        ClientWidth = 831
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1527,8 +1527,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1544,22 +1544,22 @@ object MainForm: TMainForm
       end
       object GroupBox1: TGroupBox
         Left = 128
-        Height = 417
+        Height = 414
         Top = 16
-        Width = 837
+        Width = 835
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Compare two folders'
-        ClientHeight = 394
-        ClientWidth = 829
+        ClientHeight = 393
+        ClientWidth = 831
         DragMode = dmAutomatic
         Font.Height = -13
         ParentFont = False
         TabOrder = 0
         object lblStatusA: TLabel
           Left = 8
-          Height = 16
+          Height = 13
           Top = 336
-          Width = 49
+          Width = 43
           Caption = 'Status: '
           Font.Style = [fsBold]
           ParentColor = False
@@ -1598,10 +1598,10 @@ object MainForm: TMainForm
         end
         object ZVDateTimePickerCompareDirsTab: TZVDateTimePicker
           Left = 347
-          Height = 20
+          Height = 24
           Hint = 'Enter date and time (hours and minutes) '
           Top = 200
-          Width = 151
+          Width = 138
           CenturyFrom = 1941
           MaxDate = 2958465
           MinDate = 42736
@@ -1623,10 +1623,10 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxCompareDirsTab: TCheckBox
           Left = 347
-          Height = 18
+          Height = 20
           Hint = 'After choosing FolderA and FolderB, set a date and '#13#10'time ahead of current time and then click Compare Now.'
           Top = 168
-          Width = 113
+          Width = 108
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxCompareTwoDirectoriesTabChange
           TabOrder = 2
@@ -1634,8 +1634,8 @@ object MainForm: TMainForm
         object StatusBar6: TStatusBar
           Left = 8
           Height = 23
-          Top = 367
-          Width = 803
+          Top = 364
+          Width = 801
           Align = alNone
           Anchors = [akLeft, akRight]
           AutoSize = False
@@ -1678,7 +1678,7 @@ object MainForm: TMainForm
           Left = 104
           Height = 16
           Top = 5
-          Width = 93
+          Width = 87
           Caption = 'Select Folder A'
           ParentColor = False
         end
@@ -1686,7 +1686,7 @@ object MainForm: TMainForm
           Left = 608
           Height = 16
           Top = 5
-          Width = 92
+          Width = 86
           Caption = 'Select Folder B'
           ParentColor = False
         end
@@ -1694,7 +1694,7 @@ object MainForm: TMainForm
           Left = 520
           Height = 16
           Top = 275
-          Width = 95
+          Width = 90
           BorderSpacing.Left = 5
           Caption = '# Files in Fol B:'
           ParentColor = False
@@ -1706,7 +1706,7 @@ object MainForm: TMainForm
           Left = 648
           Height = 16
           Top = 275
-          Width = 21
+          Width = 20
           Caption = '  ...'
           ParentColor = False
         end
@@ -1729,7 +1729,7 @@ object MainForm: TMainForm
           Left = 8
           Height = 16
           Top = 275
-          Width = 97
+          Width = 91
           Caption = '# Files in Fol A:'
           ParentColor = False
         end
@@ -1743,10 +1743,10 @@ object MainForm: TMainForm
         end
         object cbUNCModeCompFolders: TCheckBox
           Left = 347
-          Height = 18
+          Height = 20
           Hint = 'For Windows users, if ticked, two UNC path'#13#10'fields will allow the user to compare two '#13#10'network paths'
           Top = 72
-          Width = 92
+          Width = 85
           Caption = 'UNC Mode?'
           OnChange = cbUNCModeCompFoldersChange
           ParentShowHint = False
@@ -1755,7 +1755,7 @@ object MainForm: TMainForm
         end
         object edtUNCPathCompareA: TEdit
           Left = 8
-          Height = 22
+          Height = 24
           Top = 32
           Width = 300
           OnChange = edtUNCPathCompareAChange
@@ -1765,7 +1765,7 @@ object MainForm: TMainForm
         end
         object edtUNCPathCompareB: TEdit
           Left = 520
-          Height = 22
+          Height = 24
           Top = 32
           Width = 300
           OnChange = edtUNCPathCompareBChange
@@ -1775,10 +1775,10 @@ object MainForm: TMainForm
         end
         object cbSaveComparisons: TCheckBox
           Left = 347
-          Height = 18
+          Height = 20
           Hint = 'Save the results of the comparison.'#13#10'Filenames, hash values etc will be '#13#10'auto-saved to a CSV file in the location'#13#10'of where QuickHash is running from.'
           Top = 102
-          Width = 99
+          Width = 91
           Caption = 'Log Results?'
           Checked = True
           OnChange = cbSaveComparisonsChange
@@ -1789,10 +1789,10 @@ object MainForm: TMainForm
         end
         object cbOverrideFileCountDiffer: TCheckBox
           Left = 347
-          Height = 18
+          Height = 20
           Hint = 'If the file count of both folders are different'#13#10'proceed anyway to hash all the files in both'#13#10'(''Save Results?'' must be enabled for this feature)'
           Top = 136
-          Width = 157
+          Width = 142
           Caption = 'Cont. if count differs?'
           OnChange = cbOverrideFileCountDifferChange
           ParentShowHint = False
@@ -1804,8 +1804,8 @@ object MainForm: TMainForm
     object TabSheet5: TTabSheet
       Hint = 'Compute a SHA-1 hash of a physical disk in Windows.'#13#10'Must run QuickHash as administrator with '#13#10'Windows Vista or above'
       Caption = 'Disks'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       object btnCallDiskHasherModule: TButton
         Left = 376
         Height = 25
@@ -1837,8 +1837,8 @@ object MainForm: TMainForm
     end
     object TabSheet8: TTabSheet
       Caption = 'Base64 Data'
-      ClientHeight = 573
-      ClientWidth = 985
+      ClientHeight = 650
+      ClientWidth = 983
       object AlgorithmChoiceRadioBox7: TRadioGroup
         Left = 16
         Height = 129
@@ -1854,8 +1854,8 @@ object MainForm: TMainForm
         ChildSizing.ShrinkVertical = crsScaleChilds
         ChildSizing.Layout = cclLeftToRightThenTopToBottom
         ChildSizing.ControlsPerLine = 1
-        ClientHeight = 106
-        ClientWidth = 96
+        ClientHeight = 108
+        ClientWidth = 100
         Font.Height = -13
         ItemIndex = 1
         Items.Strings = (
@@ -1871,13 +1871,13 @@ object MainForm: TMainForm
       end
       object TextHashingGroupBox1: TGroupBox
         Left = 120
-        Height = 574
+        Height = 614
         Top = 10
-        Width = 847
+        Width = 845
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Base64 Decoder and Hasher'
-        ClientHeight = 551
-        ClientWidth = 839
+        ClientHeight = 593
+        ClientWidth = 841
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -1897,7 +1897,7 @@ object MainForm: TMainForm
           Left = 8
           Height = 25
           Hint = 'Decode a folder of Base64 encoded files'
-          Top = 168
+          Top = 216
           Width = 163
           Caption = 'Decode and hash fileS'
           OnClick = btnB64FileSChooserClick
@@ -1907,7 +1907,7 @@ object MainForm: TMainForm
           Left = 8
           Height = 25
           Hint = 'Just a useful feature to allow you to decode Base64 files. '#13#10'Original files are left in situ. New decoded copies are made'#13#10'and saved to the same folder. No hashing conducted.'
-          Top = 464
+          Top = 512
           Width = 163
           Caption = 'Decode and Save files...'
           OnClick = btnB64JustDecodeFilesClick
@@ -1915,9 +1915,9 @@ object MainForm: TMainForm
         end
         object b64StringGrid1File: TStringGrid
           Left = 8
-          Height = 96
+          Height = 136
           Top = 56
-          Width = 823
+          Width = 821
           Anchors = [akTop, akLeft, akRight]
           ColCount = 4
           Columns = <          
@@ -1942,8 +1942,8 @@ object MainForm: TMainForm
         object b64StringGrid2FileS: TStringGrid
           Left = 8
           Height = 224
-          Top = 216
-          Width = 823
+          Top = 256
+          Width = 821
           Anchors = [akTop, akLeft, akRight]
           AutoAdvance = aaDown
           ColCount = 4
@@ -1969,29 +1969,29 @@ object MainForm: TMainForm
           TitleFont.Height = -13
         end
         object b64ProgressFileS: TEdit
-          Left = 192
+          Left = 184
           Height = 24
           Hint = 'Progress of Base64 decoding of FileS will show here'
-          Top = 168
-          Width = 635
+          Top = 216
+          Width = 633
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           TabOrder = 5
         end
         object b64DecoderProgress: TEdit
-          Left = 192
+          Left = 184
           Height = 24
           Hint = 'Progress of Base64 decoding of FileS will show here'
-          Top = 464
-          Width = 635
+          Top = 512
+          Width = 633
           Anchors = [akTop, akLeft, akRight]
           Color = clSilver
           TabOrder = 6
         end
         object lblB64DecoderWarning: TLabel
-          Left = 56
+          Left = 16
           Height = 32
-          Top = 504
+          Top = 552
           Width = 228
           Caption = '(Simply for creating decoded copies of '#13#10'encoded Base64 files. No hashing done)'
           ParentColor = False
@@ -2026,10 +2026,10 @@ object MainForm: TMainForm
     AnchorSideRight.Side = asrBottom
     Cursor = crHandPoint
     Left = 736
-    Height = 16
+    Height = 13
     Hint = 'Click to open URL in browser'
     Top = 1
-    Width = 207
+    Width = 170
     BorderSpacing.Right = 10
     Caption = 'http://www.quickhash-gui.org'
     Font.Color = clBlue

--- a/unit2.lfm
+++ b/unit2.lfm
@@ -19,11 +19,11 @@ object MainForm: TMainForm
     Height = 692
     Top = 24
     Width = 991
-    ActivePage = TabSheet3
+    ActivePage = TabSheet1
     Anchors = [akTop, akLeft, akRight, akBottom]
     ParentShowHint = False
     ShowHint = True
-    TabIndex = 2
+    TabIndex = 0
     TabOrder = 0
     object TabSheet1: TTabSheet
       Hint = 'Hash portions of text'
@@ -63,6 +63,7 @@ object MainForm: TMainForm
             ''
             ''
             ''
+            ''
           )
           MaxLength = 500000000
           OnChange = HashText
@@ -83,6 +84,7 @@ object MainForm: TMainForm
           Font.Height = -13
           Lines.Strings = (
             '...hash value'
+            ''
             ''
             ''
             ''
@@ -272,7 +274,7 @@ object MainForm: TMainForm
     object TabSheet2: TTabSheet
       Hint = 'Hash a single file (useful for hashing disks in Linux)'
       Caption = 'F&ile'
-      ClientHeight = 637
+      ClientHeight = 653
       ClientWidth = 985
       ParentShowHint = False
       object FileHashingGroupBox: TGroupBox
@@ -294,7 +296,7 @@ object MainForm: TMainForm
           Left = 552
           Height = 32
           Top = 47
-          Width = 264
+          Width = 294
           Caption = 'As root, this section can be used to hash disks'#10'e.g. /dev/sdX or /dev/sdaX, or /dev/hdX'
           ParentColor = False
           WordWrap = True
@@ -317,7 +319,7 @@ object MainForm: TMainForm
         end
         object edtFileNameToBeHashed: TEdit
           Left = 6
-          Height = 24
+          Height = 22
           Top = 96
           Width = 826
           Anchors = [akTop, akLeft, akRight]
@@ -328,10 +330,10 @@ object MainForm: TMainForm
         end
         object btnHashFile: TButton
           Left = 6
-          Height = 23
+          Height = 20
           Hint = 'Choose a single file to hash (or Linux physical device e.g. /dev/sda)'
           Top = 64
-          Width = 83
+          Width = 91
           AutoSize = True
           Caption = 'Select &File'
           Color = 8454016
@@ -344,16 +346,16 @@ object MainForm: TMainForm
         end
         object StatusBar1: TStatusBar
           Left = 0
-          Height = 20
-          Top = 357
-          Width = 846
+          Height = 15
+          Top = 360
+          Width = 842
           Panels = <>
         end
         object lblDragAndDropNudge: TLabel
           Left = 112
           Height = 16
           Top = 64
-          Width = 115
+          Width = 127
           Caption = 'or drag n drop a file'
           ParentColor = False
         end
@@ -374,13 +376,14 @@ object MainForm: TMainForm
             ''
             ''
             ''
+            ''
           )
           TabOrder = 3
           WordWrap = False
         end
         object lbleExpectedHash: TLabeledEdit
           Left = 8
-          Height = 24
+          Height = 22
           Hint = 'Paste an existing hash value here to see if'#13#10'the generated file hash matches it, or not. '
           Top = 264
           Width = 824
@@ -410,10 +413,10 @@ object MainForm: TMainForm
         end
         object ZVDateTimePickerFileTab: TZVDateTimePicker
           Left = 8
-          Height = 24
+          Height = 20
           Hint = 'Enter date and time (hours and minutes) '#13#10'to start the process. Must be in the future!'
           Top = 32
-          Width = 138
+          Width = 151
           CenturyFrom = 1941
           MaxDate = 72686
           MinDate = 42736
@@ -437,10 +440,10 @@ object MainForm: TMainForm
         end
         object lblschedulertickboxFileTab: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Hint = 'Tick and set a date and time ahead of current time'#13#10'and then select the file to hash.'
           Top = 8
-          Width = 108
+          Width = 113
           Caption = 'Start at a time:'
           OnChange = lblschedulertickboxFileTabChange
           ParentShowHint = False
@@ -477,9 +480,9 @@ object MainForm: TMainForm
         end
         object cbFlipCaseFILE: TCheckBox
           Left = 8
-          Height = 20
+          Height = 18
           Top = 208
-          Width = 88
+          Width = 93
           Caption = 'Switch case'
           OnChange = cbFlipCaseFILEChange
           TabOrder = 9
@@ -555,7 +558,7 @@ object MainForm: TMainForm
           Height = 20
           Hint = 'All files and subdirectories below the chosen '#10'directory will be hashed, subject to selected'#10'options. Recursive by default.'
           Top = 96
-          Width = 109
+          Width = 105
           AutoSize = True
           Caption = 'Select &Folder'
           Color = 8454016
@@ -601,7 +604,7 @@ object MainForm: TMainForm
           Height = 20
           Hint = 'Press this to copy entire grid content to RAM'
           Top = 96
-          Width = 90
+          Width = 86
           AutoSize = True
           Caption = 'Clipboard'
           Enabled = False
@@ -878,19 +881,19 @@ object MainForm: TMainForm
     object TabSheet4: TTabSheet
       Hint = 'Choose a directory, have its content hashed, files are copied to destination, and re-hashed.'
       Caption = '&Copy'
-      ClientHeight = 643
-      ClientWidth = 987
+      ClientHeight = 653
+      ClientWidth = 985
       ParentShowHint = False
       ShowHint = True
       object CopyFilesHashingGroupBox: TGroupBox
         Left = 120
         Height = 596
         Top = 8
-        Width = 845
+        Width = 843
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Hash files in chosen directory, copy them, and re-hash the copied files (recursive by default) '
         ClientHeight = 573
-        ClientWidth = 837
+        ClientWidth = 835
         Color = clForm
         Font.Height = -13
         ParentColor = False
@@ -900,10 +903,10 @@ object MainForm: TMainForm
           Left = 8
           Height = 184
           Top = 8
-          Width = 826
+          Width = 824
           Anchors = [akTop, akLeft, akRight]
           ClientHeight = 184
-          ClientWidth = 826
+          ClientWidth = 824
           TabOrder = 3
           OnClick = Panel1CopyAndHashOptionsClick
           object CheckBoxListOfDirsOnly: TCheckBox
@@ -1064,7 +1067,7 @@ object MainForm: TMainForm
             AnchorSideTop.Control = pbCopy
             AnchorSideTop.Side = asrBottom
             AnchorSideRight.Control = pbCopy
-            Left = 378
+            Left = 377
             Height = 16
             Top = 139
             Width = 12
@@ -1189,7 +1192,7 @@ object MainForm: TMainForm
           Left = 0
           Height = 15
           Top = 558
-          Width = 837
+          Width = 835
           Panels = <>
           ParentShowHint = False
         end
@@ -1280,8 +1283,8 @@ object MainForm: TMainForm
     end
     object TabSheet7: TTabSheet
       Caption = 'Compare Two Files'
-      ClientHeight = 643
-      ClientWidth = 987
+      ClientHeight = 653
+      ClientWidth = 985
       object AlgorithmChoiceRadioBox5: TRadioGroup
         Left = 16
         Height = 129
@@ -1318,11 +1321,11 @@ object MainForm: TMainForm
         Left = 120
         Height = 296
         Top = 10
-        Width = 845
+        Width = 843
         Anchors = [akTop, akLeft, akRight]
         Caption = 'Choose two files and click ''Compare Files'''
         ClientHeight = 273
-        ClientWidth = 837
+        ClientWidth = 835
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1414,7 +1417,7 @@ object MainForm: TMainForm
           Left = 0
           Height = 15
           Top = 258
-          Width = 837
+          Width = 835
           Panels = <>
         end
         object edtFileAName: TEdit
@@ -1422,7 +1425,7 @@ object MainForm: TMainForm
           Height = 22
           Hint = 'Path to the file you wish to analyse. '#13#10'Type or paste path here directly, '#13#10'or use the button to the left to select it'
           Top = 9
-          Width = 655
+          Width = 653
           Anchors = [akTop, akLeft, akRight]
           ParentShowHint = False
           ShowHint = True
@@ -1434,7 +1437,7 @@ object MainForm: TMainForm
           Height = 22
           Hint = 'Path to the second file you wish to analyse. '#13#10'Type or paste path here directly, '#13#10'or use the button to the left to select it'
           Top = 72
-          Width = 655
+          Width = 653
           Anchors = [akTop, akLeft, akRight]
           ParentShowHint = False
           ShowHint = True
@@ -1480,8 +1483,8 @@ object MainForm: TMainForm
     end
     object TabSheet6: TTabSheet
       Caption = 'Compare Two Folders'
-      ClientHeight = 643
-      ClientWidth = 987
+      ClientHeight = 653
+      ClientWidth = 985
       OnContextPopup = TabSheet6ContextPopup
       ParentShowHint = False
       object GroupBox2: TGroupBox
@@ -1491,12 +1494,12 @@ object MainForm: TMainForm
         AnchorSideRight.Side = asrBottom
         Left = 128
         Height = 177
-        Top = 439
-        Width = 839
+        Top = 449
+        Width = 837
         Anchors = [akLeft, akRight, akBottom]
         Caption = 'Summary'
         ClientHeight = 154
-        ClientWidth = 831
+        ClientWidth = 829
         Font.Height = -13
         ParentFont = False
         TabOrder = 1
@@ -1541,13 +1544,13 @@ object MainForm: TMainForm
       end
       object GroupBox1: TGroupBox
         Left = 128
-        Height = 407
+        Height = 417
         Top = 16
-        Width = 839
+        Width = 837
         Anchors = [akTop, akLeft, akRight, akBottom]
         Caption = 'Compare two folders'
-        ClientHeight = 384
-        ClientWidth = 831
+        ClientHeight = 394
+        ClientWidth = 829
         DragMode = dmAutomatic
         Font.Height = -13
         ParentFont = False
@@ -1631,8 +1634,8 @@ object MainForm: TMainForm
         object StatusBar6: TStatusBar
           Left = 8
           Height = 23
-          Top = 357
-          Width = 805
+          Top = 367
+          Width = 803
           Align = alNone
           Anchors = [akLeft, akRight]
           AutoSize = False

--- a/unit2.pas
+++ b/unit2.pas
@@ -2250,6 +2250,7 @@ var
   PageControl1.ActivePage := Tabsheet3;  // Ensure FileS tab activated if triggered via menu
   FileCounter                   := 1;
   TotalBytesRead                := 0;
+  lblNoFilesInDir.Caption       := '...';
   lblTimeTaken3.Caption         := '...';
   lblTimeTaken4.Caption         := '...';
   lblFilesExamined.Caption      := '...';
@@ -2257,7 +2258,11 @@ var
   lblTotalBytesExamined.Caption := '...';
   pbFileS.Position              := 0;
   Label5.Caption                := 'This area will be populated once the scan is complete...please wait!';
+  StopScan1 := false;
 
+  // In case user pressed stop prior to just selecting a folder, free the resources
+  TotalFilesToExamine := nil;
+  FS := nil;
   // Empty database table TBL_FILES from earlier runs, otherwise entries from
   // previous runs will be listed with this new run
   frmSQLiteDBases.EmptyDBTable('TBL_FILES', RecursiveDisplayGrid1);
@@ -2288,7 +2293,7 @@ var
 
        // Now lets recursively count each file,
        start := Now;
-       lblTimeTaken3.Caption := 'Started: '+ FormatDateTime('dd/mm/yy hh:mm:ss', Start);
+       lblTimeTaken3.Caption := 'Started: '+ FormatDateTime('YY/MM/DD HH:MM:SS', Start);
        StatusBar2.SimpleText := ' C O U N T I N G  F I L E S...P L E A S E  W A I T   A   M O M E N T ...';
        Label5.Visible        := true;
 

--- a/unit2.pas
+++ b/unit2.pas
@@ -1098,10 +1098,8 @@ begin
        ShowMessage('File size is zero. The file cannot be hashed');
        Abort;
       end;
-    end
-  else
-    ShowMessage('An error occured opening the file. Error code: ' +  SysErrorMessageUTF8(GetLastOSError));
-  end;
+    end;
+end;
 
 procedure TMainForm.btnLaunchDiskModuleClick(Sender: TObject);
 begin
@@ -1263,7 +1261,7 @@ begin
   else cbToggleInputDataToOutputFile.Caption := 'Source text INcluded in output';
 end;
 
-// Behaviours for the UNC tick box in "Compare Two Directories" tab
+// Behaviours for the UNC tick box in "Compare Two Folders" tab
 procedure TMainForm.cbUNCModeCompFoldersChange(Sender: TObject);
 begin
   if cbUNCModeCompFolders.Checked then
@@ -2611,7 +2609,7 @@ begin
       NeedToSave := true;
       // Create the log file if it does not exist already
       if ForceDirectories(GetAppConfigDir(false)) then // Create .config folder in users home folder
-      fsSaveFolderComparisonsLogFile := TFileStream.Create(GetAppConfigDir(false) +'QH_results'+FormatDateTime('_YYYY_MM_DD_HH_MM_SS', StartTime)+'.txt', fmCreate);
+      fsSaveFolderComparisonsLogFile := TFileStream.Create(GetAppConfigDir(false) +'QH_CompareResults'+FormatDateTime('_YYYY_MM_DD_HH_MM_SS', StartTime)+'.txt', fmCreate);
     end;
 
     // Process FolderA first. Find all the files initially
@@ -3488,7 +3486,7 @@ begin
         2: TabRadioGroup2 := AlgorithmChoiceRadioBox3;  //RadioGroup for FileS.
         3: TabRadioGroup2 := AlgorithmChoiceRadioBox4;  //RadioGroup for Copy.
         4: TabRadioGroup2 := AlgorithmChoiceRadioBox5;  //RadioGroup for Compare Two Files.
-        5: TabRadioGroup2 := AlgorithmChoiceRadioBox6;  //RadioGroup for Compare Direcories.
+        5: TabRadioGroup2 := AlgorithmChoiceRadioBox6;  //RadioGroup for Compare Two Folders.
         7: TabRadioGroup2 := AlgorithmChoiceRadioBox7;  //RadioGroup for Base64
   end;
 
@@ -3499,6 +3497,15 @@ begin
     fsFileToBeHashed := TFileStream.Create(FileToBeHashed, fmOpenRead or fmShareDenyNone);
     strFileSize      := FormatByteSize(fsFileToBeHashed.Size);
     IntFileSize      := fsFileToBeHashed.Size;
+  except
+    on E:Exception do
+      result := (FileToBeHashed + ' could not be accessed because: ' + E.Message);
+  end;
+
+  // Only continue if valid file handle
+  if fsFileToBeHashed.Handle > -1 then
+  begin
+
     pbFile.Position  := 0;
     pbFile.Max       := 100;
 
@@ -3669,8 +3676,8 @@ begin
         {$endif}
         end;  // End of xxHash
     end; // end of case statement
-  finally
-   if PageControl1.ActivePage = TabSheet2 then
+
+  if PageControl1.ActivePage = TabSheet2 then
      begin
        // Last sweep to catch data that fell outside the loop counter
        // i.e. if the loop counter is 40, then the last 40 reads won't be in the
@@ -3681,8 +3688,8 @@ begin
        LoopCounter := 0;
      end;
     Application.ProcessMessages;
-    // Free the source file
-    fsFileToBeHashed.free;
+    // Free the source file if it was successfully opened for read access
+    if fsFileToBeHashed.Handle > -1 then fsFileToBeHashed.free;
   end;
 end;
 

--- a/unit2.pas
+++ b/unit2.pas
@@ -2960,6 +2960,7 @@ begin
   pbCopy.Position                  := 0;
   LoopCounter                      := 0;
   Button8CopyAndHash.Enabled       := false; // disable the go button until finished
+  StopScan2                        := false;
 
   // Empty database table TBL_COPY from any earlier runs, otherwise entries from
   // previous runs will be listed with this new run

--- a/uprogress.lfm
+++ b/uprogress.lfm
@@ -1,8 +1,8 @@
 object frmProgress: TfrmProgress
-  Left = 619
+  Left = 627
   Height = 348
   Hint = 'Close this window if you wish to abort.'
-  Top = 500
+  Top = 317
   Width = 421
   Caption = 'QuickHash - Disk Hashing Module'
   ClientHeight = 348


### PR DESCRIPTION
v3.0.1 (Feb 2018)
The "Select File" in File tab generated an unnecessary error if the user cancelled the selection. Now it just cancels as expected
If QuickHash cannot get a handle to a file because it is open without share permissions by the OS, QuickHash should now silently proceed and simply report that the file could not be accessed in the hash column
The SQLite database is now located in the systems temporary directory and deleted afterwards rather than appearing in the root of the launch path.
In the FileS tab, if the user aborted a scan using Stop button and selected a new folder, nothing would happen because a boolean flag was not being reset properly. That was fixed. Date formatting also adjusted to YY/MM/DD (e.g. 18/01/31)
In the Disks tab, if the user had removable drive bays, often they would get error : "Could not convert variant of type (Null) into type Int64". That "should" now be fixed (very hard to debug!). 
In the disks tab, dates were being shown as dd/mm/yy. Changed to YY/MM/DD in line with the rest of QuickHash
In the disks tab, logical volumes were being shown with their API prefix (e.g. \\?\F:). It still will on initial selection but thereafter (once the hashing has started) it is converted to "F:"
