### PR TITLE
TXMLPropStorage: don't set config name

### DIFF
--- a/unit2.lfm
+++ b/unit2.lfm
@@ -2208,7 +2208,7 @@ object MainForm: TMainForm
   end
   object QH_MainFormXMLPropStorage: TXMLPropStorage
     StoredValues = <>
-    FileName = 'QHConfig.xml'
+    FileName = ''
     Left = 32
     Top = 584
   end


### PR DESCRIPTION
TXMLPropStorage has a default handler if you don't set a FileName.

    Under Windows the settings will be saved in the application directory as PROGRAMNAME.xml.
    Under Unix/Linux/macOS it will be saved in the home directory of the current user as .PROGRAMNAME

It is therefore a very good idea to leave the filename blank for unix programs meant to be run by normal users.

https://wiki.lazarus.freepascal.org/TXMLPropStorage#Notes

Closes https://github.com/tedsmith/quickhash/issues/113